### PR TITLE
refactor: rename go module to allow installing with go install

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build rpc as library
-      run: go build -buildmode=c-shared -o rpc.so ./cmd   
+      run: go build -buildmode=c-shared -o rpc.so ./cmd/rpc   
     - name: Restore dependencies
       run: cd samples/dotnet && dotnet restore
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,12 +60,12 @@ jobs:
       # Runs a single command using the runners shell
       - name: build go
         if: ${{ matrix.os == 'windows-2019' }}
-        run: go build -o rpc.exe ./cmd
+        run: go build -o rpc.exe ./cmd/rpc
       
       # Runs a single command using the runners shell
       - name: build go
         if: ${{ matrix.os != 'windows-2019' }}
-        run: go build -o rpc ./cmd
+        run: go build -o rpc ./cmd/rpc
 
       - name: GitHub Upload Release Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 realthing
 rpc
+!/cmd/rpc
 *.exe
 !/internal/rpc
 coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go install github.com/google/go-licenses@v1.0.0
 RUN go-licenses save ./... --save_path=licenses
 
 # Build rpc
-RUN CGO_ENABLED=0 LDFLAGS="-s -w" GOOS=linux GOARCH=amd64 go build -o /build/rpc ./cmd/main.go
+RUN CGO_ENABLED=0 LDFLAGS="-s -w" GOOS=linux GOARCH=amd64 go build -o /build/rpc ./cmd/rpc/main.go
 
 FROM scratch
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Remote Provisioning Client (RPC)
+
 ![CodeQL](https://img.shields.io/github/actions/workflow/status/open-amt-cloud-toolkit/rpc-go/codeql-analysis.yml?style=for-the-badge&label=CodeQL&logo=github)
 ![Build](https://img.shields.io/github/actions/workflow/status/open-amt-cloud-toolkit/rpc-go/main.yml?style=for-the-badge&logo=github)
 ![Codecov](https://img.shields.io/codecov/c/github/open-amt-cloud-toolkit/rpc-go?style=for-the-badge&logo=codecov)
@@ -18,7 +19,7 @@ The Remote Provisioning Client (RPC) is an application that assists with activat
 ---
 
 
-## Prerequisites 
+## Prerequisites
 
 - [Golang](https://go.dev/dl/)
 
@@ -26,26 +27,32 @@ The Remote Provisioning Client (RPC) is an application that assists with activat
 
 ### Windows
 
-#### As executable: 
+#### As executable:
+
 ```
-go build -o rpc.exe ./cmd/main.go
+go build -o rpc.exe ./cmd/rpc/main.go
 ```
-#### As Library: 
+
+#### As Library:
+
 ```
-go build -buildmode=c-shared -o rpc.dll ./cmd
+go build -buildmode=c-shared -o rpc.dll ./cmd/rpc
 ```
 
 ### Linux
 
-#### As executable: 
+#### As executable:
+
 ```
-go build -o rpc ./cmd/main.go
+go build -o rpc ./cmd/rpc/main.go
 ```
 
-#### As Library: 
+#### As Library:
+
 ```
-go build -buildmode=c-shared -o librpc.so ./cmd   
+CGO_ENABLED=1 go build -buildmode=c-shared -o librpc.so ./cmd/rpc
 ```
+
 ### Docker image
 
 ```bash
@@ -55,21 +62,24 @@ docker build -t rpc-go:latest .
 ## Run
 
 Install the executable on a target device and then run from a terminal/shell
-command line with <b>adminstrator privileges</b>.  
+command line with <b>adminstrator privileges</b>.
 
-For usage, call the executable with no additional parameters.  
+For usage, call the executable with no additional parameters.
 
 ### Windows
+
 ```shell
 .\rpc
 ```
 
 ### Linux
+
 ```bash
 sudo ./rpc
 ```
 
 ### Docker
+
 ```bash
 $ docker run --rm -it --device /dev/mei0 rpc-go:latest
 ```
@@ -78,7 +88,7 @@ $ docker run --rm -it --device /dev/mei0 rpc-go:latest
 
 # Dev tips for passing CI Checks
 
-- Ensure code is formatted correctly with `gofmt -s -w ./` 
+- Ensure code is formatted correctly with `gofmt -s -w ./`
 - Ensure all unit tests pass with `go test ./...`
 - Ensure code has been linted with `docker run --rm -v ${pwd}:/app -w /app golangci/golangci-lint:v1.52.2 golangci-lint run -v`
 
@@ -92,4 +102,4 @@ $ docker run --rm -it --device /dev/mei0 rpc-go:latest
 
 - Need additional support or want to get the latest news and events about Open AMT? Connect with the team directly through Discord.
 
-    [![Discord Banner 1](https://discordapp.com/api/guilds/1063200098680582154/widget.png?style=banner2)](https://discord.gg/DKHeUNEWVH)
+  [![Discord Banner 1](https://discordapp.com/api/guilds/1063200098680582154/widget.png?style=banner2)](https://discord.gg/DKHeUNEWVH)

--- a/cmd/rpc/lib.go
+++ b/cmd/rpc/lib.go
@@ -14,8 +14,9 @@ import (
 	"encoding/csv"
 	"io"
 	"os"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/cmd/rpc/main.go
+++ b/cmd/rpc/main.go
@@ -6,13 +6,14 @@ package main
 
 import (
 	"os"
-	"rpc/internal/amt"
-	"rpc/internal/flags"
-	"rpc/internal/local"
-	"rpc/internal/rps"
-	"rpc/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/local"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/rps"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 const AccessErrMsg = "Failed to execute due to access issues. " +
@@ -114,7 +115,6 @@ func updateConnectionSettings(flags *flags.Flags) error {
 	}
 	return nil
 }
-
 func handleErrorAndExit(err error) {
 	if customErr, ok := err.(utils.CustomError); ok {
 		if err != utils.HelpRequested {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module rpc
+module github.com/open-amt-cloud-toolkit/rpc-go/v2
 
 go 1.23.0
 

--- a/internal/amt/commands.go
+++ b/internal/amt/commands.go
@@ -7,11 +7,12 @@ package amt
 import (
 	"errors"
 	"fmt"
-	"rpc/pkg/pthi"
-	"rpc/pkg/utils"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/pthi"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 //TODO: Ensure pointers are freed properly throughout this file

--- a/internal/amt/commands_test.go
+++ b/internal/amt/commands_test.go
@@ -7,10 +7,11 @@ package amt
 import (
 	"errors"
 	"fmt"
-	"rpc/pkg/pthi"
-	"rpc/pkg/utils"
 	"testing"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/pthi"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -15,12 +15,13 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"math/big"
 	"net"
-	"software.sslmate.com/src/go-pkcs12"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 type Composite struct {

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -6,9 +6,10 @@
 package certs
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func RunNewSignedCompositeTest(t *testing.T, testDer string) {

--- a/internal/config/lmsTls.go
+++ b/internal/config/lmsTls.go
@@ -10,10 +10,10 @@ import (
 	"errors"
 	"strconv"
 
-	"rpc/internal/amt"
-	"rpc/internal/certs"
 	"strings"
 
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/certs"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/internal/config/lmsTls_test.go
+++ b/internal/config/lmsTls_test.go
@@ -13,9 +13,10 @@ import (
 	"io/fs"
 	"math/big"
 	"os"
-	"rpc/internal/certs"
 	"testing"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/certs"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/internal/flags/activate.go
+++ b/internal/flags/activate.go
@@ -9,7 +9,8 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/flags/activate_test.go
+++ b/internal/flags/activate_test.go
@@ -7,10 +7,11 @@ package flags
 
 import (
 	"os"
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/flags/configure.go
+++ b/internal/flags/configure.go
@@ -12,9 +12,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/wifi"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"

--- a/internal/flags/configure_test.go
+++ b/internal/flags/configure_test.go
@@ -8,10 +8,11 @@ package flags
 import (
 	"fmt"
 	"os"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/wifi"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"

--- a/internal/flags/deactivate.go
+++ b/internal/flags/deactivate.go
@@ -7,7 +7,8 @@ package flags
 
 import (
 	"fmt"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 func (f *Flags) handleDeactivateCommand() error {

--- a/internal/flags/deactivate_test.go
+++ b/internal/flags/deactivate_test.go
@@ -6,8 +6,9 @@
 package flags
 
 import (
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -13,13 +13,14 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"rpc/internal/amt"
-	"rpc/internal/config"
-	"rpc/internal/smb"
-	"rpc/pkg/utils"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/smb"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	configv2 "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/config"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/security"

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -12,11 +12,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"rpc/internal/config"
-	"rpc/internal/smb"
-	"rpc/pkg/pthi"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/smb"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/pthi"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"gopkg.in/yaml.v3"
 

--- a/internal/flags/info.go
+++ b/internal/flags/info.go
@@ -7,7 +7,8 @@ package flags
 
 import (
 	"flag"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 type AmtInfoFlags struct {

--- a/internal/flags/info_test.go
+++ b/internal/flags/info_test.go
@@ -6,9 +6,10 @@
 package flags
 
 import (
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/flags/maintenance.go
+++ b/internal/flags/maintenance.go
@@ -12,8 +12,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"rpc/internal/amt"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/flags/maintenance_test.go
+++ b/internal/flags/maintenance_test.go
@@ -8,9 +8,10 @@ package flags
 import (
 	"os"
 	"path/filepath"
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/flags/version.go
+++ b/internal/flags/version.go
@@ -6,7 +6,7 @@
 package flags
 
 import (
-	"rpc/pkg/utils"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 func (f *Flags) handleVersionCommand() error {

--- a/internal/lm/engine.go
+++ b/internal/lm/engine.go
@@ -7,12 +7,14 @@ package lm
 import (
 	"bytes"
 	"encoding/binary"
-	"rpc/pkg/pthi"
 	"sync"
 	"time"
 
-	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/apf"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/pthi"
+
 	log "github.com/sirupsen/logrus"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/apf"
 )
 
 // LMConnection is struct for managing connection to LMS

--- a/internal/lm/engine_test.go
+++ b/internal/lm/engine_test.go
@@ -6,12 +6,14 @@ package lm
 
 import (
 	"errors"
-	"rpc/pkg/pthi"
 	"sync"
 	"testing"
 
-	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/apf"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/pthi"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/apf"
 )
 
 type MockHECICommands struct{}

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"rpc/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/local/Certificates.go
+++ b/internal/local/Certificates.go
@@ -2,14 +2,16 @@ package local
 
 import (
 	"reflect"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/concrete"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/credential"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/internal/local/Certificates_test.go
+++ b/internal/local/Certificates_test.go
@@ -2,9 +2,10 @@ package local
 
 import (
 	// "encoding/xml"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"

--- a/internal/local/activate.go
+++ b/internal/local/activate.go
@@ -16,9 +16,10 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 	pkcs12 "software.sslmate.com/src/go-pkcs12"

--- a/internal/local/activate_test.go
+++ b/internal/local/activate_test.go
@@ -7,11 +7,12 @@ package local
 
 import (
 	"crypto/x509"
-	amt2 "rpc/internal/amt"
-	"rpc/internal/certs"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	amt2 "github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/certs"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/amt/localTransport.go
+++ b/internal/local/amt/localTransport.go
@@ -11,8 +11,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"rpc/internal/lm"
 	"sync"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/lm"
 
 	"github.com/sirupsen/logrus"
 )

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -9,7 +9,10 @@ import (
 	cryptotls "crypto/tls"
 	"encoding/base64"
 	"net"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/authorization"
@@ -31,7 +34,6 @@ import (
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
-	"github.com/sirupsen/logrus"
 )
 
 type WSMANer interface {

--- a/internal/local/amtPassword.go
+++ b/internal/local/amtPassword.go
@@ -8,10 +8,12 @@ package local
 import (
 	"encoding/base64"
 	"encoding/hex"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/client"
-	log "github.com/sirupsen/logrus"
 )
 
 func (service *ProvisioningService) ChangeAMTPassword() (err error) {

--- a/internal/local/amtPassword_test.go
+++ b/internal/local/amtPassword_test.go
@@ -6,9 +6,10 @@
 package local
 
 import (
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/configure.go
+++ b/internal/local/configure.go
@@ -9,8 +9,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/url"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/local/configure_test.go
+++ b/internal/local/configure_test.go
@@ -6,9 +6,10 @@
 package local
 
 import (
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/deactivate.go
+++ b/internal/local/deactivate.go
@@ -8,8 +8,9 @@ package local
 import (
 	"crypto/tls"
 	"fmt"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/local/deactivate_test.go
+++ b/internal/local/deactivate_test.go
@@ -7,9 +7,10 @@ package local
 
 import (
 	"errors"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/ea_test.go
+++ b/internal/local/ea_test.go
@@ -9,8 +9,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"rpc/internal/flags"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/ethernet.go
+++ b/internal/local/ethernet.go
@@ -2,12 +2,14 @@ package local
 
 import (
 	"os"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
-	log "github.com/sirupsen/logrus"
 )
 
 func (service *ProvisioningService) AddEthernetSettings() (err error) {

--- a/internal/local/ethernet_test.go
+++ b/internal/local/ethernet_test.go
@@ -4,15 +4,17 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"rpc/internal/config"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
 
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
-	"github.com/stretchr/testify/assert"
 )
 
 var mockauthResponse = AuthResponse{Token: "someToken"}

--- a/internal/local/features.go
+++ b/internal/local/features.go
@@ -5,13 +5,15 @@
 package local
 
 import (
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/redirection"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/kvm"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
-	log "github.com/sirupsen/logrus"
 )
 
 func (service *ProvisioningService) SetAMTFeatures() error {

--- a/internal/local/features_test.go
+++ b/internal/local/features_test.go
@@ -5,14 +5,16 @@
 package local
 
 import (
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/redirection"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/kvm"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
-	"github.com/stretchr/testify/assert"
 )
 
 var getRedirectionResponse = redirection.Response{

--- a/internal/local/info.go
+++ b/internal/local/info.go
@@ -13,16 +13,18 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"rpc/internal/amt"
-	"rpc/internal/config"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"strconv"
 	"strings"
 
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
+
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"
-	log "github.com/sirupsen/logrus"
 )
 
 type PrivateKeyPairReference struct {

--- a/internal/local/info_test.go
+++ b/internal/local/info_test.go
@@ -8,12 +8,14 @@ package local
 import (
 	"errors"
 	"net"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
 
-	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 )
 
 var MockPRSuccess = new(MockPasswordReaderSuccess)

--- a/internal/local/linux.go
+++ b/internal/local/linux.go
@@ -9,9 +9,11 @@
 package local
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os/exec"
-	"rpc/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 func (n *RealOSNetworker) RenewDHCPLease() error {

--- a/internal/local/lps.go
+++ b/internal/local/lps.go
@@ -7,11 +7,12 @@ package local
 
 import (
 	"net/url"
-	internalAMT "rpc/internal/amt"
-	"rpc/internal/config"
-	"rpc/internal/flags"
-	"rpc/internal/local/amt"
-	"rpc/pkg/utils"
+
+	internalAMT "github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/local/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 type OSNetworker interface {

--- a/internal/local/lps_test.go
+++ b/internal/local/lps_test.go
@@ -10,11 +10,14 @@ import (
 	"encoding/xml"
 	"errors"
 	"net/http"
-	amt2 "rpc/internal/amt"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
 	"time"
+
+	amt2 "github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/authorization"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
@@ -35,7 +38,6 @@ import (
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
-	"github.com/stretchr/testify/assert"
 )
 
 type MockOSNetworker struct{}

--- a/internal/local/mebx.go
+++ b/internal/local/mebx.go
@@ -6,7 +6,7 @@
 package local
 
 import (
-	"rpc/pkg/utils"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/local/mebx_test.go
+++ b/internal/local/mebx_test.go
@@ -6,9 +6,10 @@
 package local
 
 import (
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/opstate.go
+++ b/internal/local/opstate.go
@@ -6,8 +6,8 @@
 package local
 
 import (
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/local/opstate_test.go
+++ b/internal/local/opstate_test.go
@@ -7,10 +7,11 @@ package local
 
 import (
 	"errors"
-	"rpc/internal/amt"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/internal/local/time.go
+++ b/internal/local/time.go
@@ -6,8 +6,9 @@
 package local
 
 import (
-	"rpc/pkg/utils"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/local/time_test.go
+++ b/internal/local/time_test.go
@@ -7,8 +7,9 @@ package local
 
 import (
 	"errors"
-	"rpc/internal/flags"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/tls.go
+++ b/internal/local/tls.go
@@ -7,15 +7,17 @@ package local
 
 import (
 	"os"
-	"rpc/internal/certs"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/certs"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/tls"
-	log "github.com/sirupsen/logrus"
 )
 
 const RemoteTLSInstanceId = `Intel(r) AMT 802.3 TLS Settings`

--- a/internal/local/tls_test.go
+++ b/internal/local/tls_test.go
@@ -10,15 +10,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/tls"
-	"github.com/stretchr/testify/assert"
 )
 
 func setupProvisioningService() (ProvisioningService, *MockAMT, *MockWSMAN) {

--- a/internal/local/version.go
+++ b/internal/local/version.go
@@ -8,8 +8,9 @@ package local
 import (
 	"encoding/json"
 	"fmt"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 )
 
 type VersionInfo struct {

--- a/internal/local/version_test.go
+++ b/internal/local/version_test.go
@@ -6,9 +6,10 @@
 package local
 
 import (
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/local/wifi.go
+++ b/internal/local/wifi.go
@@ -9,14 +9,16 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"rpc/internal/config"
-	"rpc/pkg/utils"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/models"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/wifi"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
-	log "github.com/sirupsen/logrus"
 )
 
 type Handles struct {

--- a/internal/local/wifi_test.go
+++ b/internal/local/wifi_test.go
@@ -10,11 +10,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"rpc/internal/config"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"strings"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/config"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/wifi"

--- a/internal/local/windows.go
+++ b/internal/local/windows.go
@@ -9,7 +9,8 @@ package local
 
 import (
 	"os/exec"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -7,11 +7,12 @@ package rps
 import (
 	"os"
 	"os/signal"
-	"rpc/internal/flags"
-	"rpc/internal/lm"
-	"rpc/pkg/utils"
 	"sync"
 	"syscall"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/lm"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/rps/message.go
+++ b/internal/rps/message.go
@@ -8,12 +8,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"os"
-	"rpc/internal/amt"
-	"rpc/internal/flags"
-	"rpc/internal/local"
-	"rpc/pkg/utils"
 	"strings"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/local"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/rps/message_test.go
+++ b/internal/rps/message_test.go
@@ -8,11 +8,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"rpc/internal/amt"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"testing"
 	"time"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/amt"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/rps/rps.go
+++ b/internal/rps/rps.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"

--- a/internal/rps/rps_test.go
+++ b/internal/rps/rps_test.go
@@ -7,11 +7,12 @@ package rps
 import (
 	"net/http"
 	"net/http/httptest"
-	"rpc/internal/flags"
-	"rpc/pkg/utils"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/internal/flags"
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"

--- a/internal/smb/samba.go
+++ b/internal/smb/samba.go
@@ -12,8 +12,9 @@ import (
 	netURL "net/url"
 	"os"
 	"os/user"
-	"rpc/pkg/utils"
 	"strings"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/hirochachacha/go-smb2"
 	log "github.com/sirupsen/logrus"

--- a/internal/smb/samba_test.go
+++ b/internal/smb/samba_test.go
@@ -8,8 +8,9 @@ package smb
 import (
 	"errors"
 	"os/user"
-	"rpc/pkg/utils"
 	"testing"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 build:
-	go build -o ./rpc ./cmd 
+	go build ./cmd/rpc

--- a/pkg/heci/windows.go
+++ b/pkg/heci/windows.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	setupapi "rpc/pkg/windows"
+	setupapi "github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/windows"
 
 	"golang.org/x/sys/windows"
 )

--- a/pkg/pthi/commands.go
+++ b/pkg/pthi/commands.go
@@ -8,7 +8,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"rpc/pkg/heci"
+
+	"github.com/open-amt-cloud-toolkit/rpc-go/v2/pkg/heci"
 )
 
 type Command struct {

--- a/pkg/pthi/commands_test.go
+++ b/pkg/pthi/commands_test.go
@@ -10,8 +10,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/apf"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/apf"
 )
 
 type MockHECICommands struct{}

--- a/pkg/pthi/status_test.go
+++ b/pkg/pthi/status_test.go
@@ -6,8 +6,9 @@
 package pthi
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAmtStatus_String(t *testing.T) {


### PR DESCRIPTION
Goal: Install rpc-go with `go install github.com/open-amt-cloud-toolkit/rpc-go/v2/cmd/rpc@latest`.

Steps taken:

- Modify module name in go.mod to `github.com/open-amt-cloud-toolkit/rpc-go/v2` to reflect location and proper versioning (required by Go toolchain)
- Move contents of `cmd` to `cmd/rpc` for proper executable naming
- Update self-imports with `find . -name '*.go' -exec sed -i 's|"rpc/|"github.com/open-amt-cloud-toolkit/rpc-go/v2/|' '{}' \;`
- Fix import grouping with `find . -name '*.go' -exec goimports -local github.com/open-amt-cloud-toolkit -w '{}' \;`
- Ensure proper formatting with `find . -name '*.go' -exec gofmt -s -w '{}' \;`
- Update README and Makefile with new `cmd/rpc` path