### PR TITLE
fix: prevent partial unprovision in CCM (only allow in ACM)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hirochachacha/go-smb2 v1.1.0
 	github.com/ilyakaznacheev/cleanenv v1.5.0
-	github.com/open-amt-cloud-toolkit/go-wsman-messages/v2 v2.25.0
+	github.com/open-amt-cloud-toolkit/go-wsman-messages/v2 v2.25.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-amt-cloud-toolkit/go-wsman-messages/v2 v2.25.0 h1:3d9yGzM8o4ghnaw4ucwHGG64lR1xvadJhtwgqaBD0z0=
-github.com/open-amt-cloud-toolkit/go-wsman-messages/v2 v2.25.0/go.mod h1:ezWfnNZ2up9X90aNy3B/5YpxCacyPB9dFANJc8UBuok=
+github.com/open-amt-cloud-toolkit/go-wsman-messages/v2 v2.25.1 h1:xFqJz7XRpRNZc0W7cUuu92xRGK+qvTCGtruMygO9sW8=
+github.com/open-amt-cloud-toolkit/go-wsman-messages/v2 v2.25.1/go.mod h1:ezWfnNZ2up9X90aNy3B/5YpxCacyPB9dFANJc8UBuok=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
Partial unprovisioning for CCM would require AMT password, and furthermore would require a
 WS-MAN call. Currently local deactivate for CCM is a HECI call/a driver call. This is simpler and prefer to keep it that way for CCM. Additionally, this is currently causing a panic.