### PR TITLE
fix: retry wsman connection while AMT settles after shbc

### DIFF
--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/general"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/certs"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
@@ -598,18 +599,37 @@ func (service *LocalActivationService) setupACMTLSConfig() (*tls.Config, error) 
 	return tlsConfig, nil
 }
 
+// connectAdminAfterActivation retries the admin connection while AMT re-arms its TLS listener post-activation.
+func (service *LocalActivationService) connectAdminAfterActivation(tlsConfig *tls.Config) (general.Response, error) {
+	var lastErr error
+
+	for attempt := 1; attempt <= hbcMaxAttempts; attempt++ {
+		err := service.wsman.SetupWsmanClient("admin", service.config.AMTPassword, service.localTLSEnforced, log.GetLevel() == log.TraceLevel, tlsConfig)
+		if err != nil {
+			return general.Response{}, fmt.Errorf("failed to setup admin WSMAN client: %w", err)
+		}
+
+		settings, err := service.wsman.GetGeneralSettings()
+		if err == nil {
+			return settings, nil
+		}
+
+		lastErr = err
+
+		if attempt < hbcMaxAttempts {
+			log.Warnf("AMT not ready yet after activation (%d/%d): %v. Waiting %s for firmware to settle...", attempt, hbcMaxAttempts, err, hbcBackoff)
+			time.Sleep(hbcBackoff)
+		}
+	}
+
+	return general.Response{}, fmt.Errorf("failed to get AMT general settings after %d attempts: %w", hbcMaxAttempts, lastErr)
+}
+
 // activateACMWithTLS performs ACM activation with TLS (new cleaner path)
 func (service *LocalActivationService) activateACMWithTLS(tlsConfig *tls.Config) error {
-	// For TLS path, we need to update the AMT password and then commit
-	// Setup WSMAN client with admin credentials, reusing the TLS config that has client certs
-	err := service.wsman.SetupWsmanClient("admin", service.config.AMTPassword, service.localTLSEnforced, log.GetLevel() == log.TraceLevel, tlsConfig)
+	generalSettings, err := service.connectAdminAfterActivation(tlsConfig)
 	if err != nil {
-		return fmt.Errorf("failed to setup admin WSMAN client: %w", err)
-	}
-	// Get general settings to obtain digest realm for password hashing
-	generalSettings, err := service.wsman.GetGeneralSettings()
-	if err != nil {
-		return fmt.Errorf("failed to get AMT general settings: %w", err)
+		return err
 	}
 
 	// Create authentication challenge with new password
@@ -881,10 +901,10 @@ func (service *LocalActivationService) convertPfxToObject(pfxb64, passphrase str
 	return pfxOut, nil
 }
 
-// HBC retry tuning.
+// AMT firmware retry tuning (shared by HBC start and the post-activation admin connection settle).
 const hbcMaxAttempts = 3
 
-var hbcBackoff = 2 * time.Second
+var hbcBackoff = 3 * time.Second
 
 // runStartHBCWithRetry invokes startSecureHostBasedConfiguration with retries on
 // transient AMT FW / HECI instability. A non-SUCCESS Status means AMT isn't armed
@@ -898,6 +918,8 @@ func (service *LocalActivationService) runStartHBCWithRetry(certsAndKeys CertsAn
 	for attempt := 1; attempt <= hbcMaxAttempts; attempt++ {
 		response, err = service.startSecureHostBasedConfiguration(certsAndKeys)
 		if err == nil && response.Status == amtStatusSuccess {
+			log.Infof("Host-Based Configuration started successfully (status=%q); AMT is transitioning to in-provisioning mode", response.Status)
+
 			return response, nil
 		}
 

--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -15,11 +15,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/general"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
+	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/upid"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
+	"go.uber.org/mock/gomock"
 	pkcs12 "software.sslmate.com/src/go-pkcs12"
 )
 
@@ -1234,6 +1237,82 @@ func TestLocalActivationService_commitCCMChanges(t *testing.T) {
 	}()
 
 	_ = service.commitCCMChanges()
+}
+
+func TestLocalActivationService_connectAdminAfterActivation(t *testing.T) {
+	// Shrink the backoff so the retry path doesn't sleep for real.
+	origBackoff := hbcBackoff
+	hbcBackoff = time.Millisecond
+
+	defer func() { hbcBackoff = origBackoff }()
+
+	settings := general.Response{}
+	settings.Body.GetResponse.DigestRealm = "Digest:TEST"
+
+	tests := []struct {
+		name      string
+		setupMock func(m *mock.MockWSMANer)
+		wantErr   bool
+	}{
+		{
+			name: "succeeds on first attempt",
+			setupMock: func(m *mock.MockWSMANer) {
+				m.EXPECT().SetupWsmanClient("admin", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().GetGeneralSettings().Return(settings, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "succeeds after the firmware settles",
+			setupMock: func(m *mock.MockWSMANer) {
+				m.EXPECT().SetupWsmanClient("admin", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				gomock.InOrder(
+					m.EXPECT().GetGeneralSettings().Return(general.Response{}, errors.New("EOF")),
+					m.EXPECT().GetGeneralSettings().Return(settings, nil),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "fails after exhausting attempts",
+			setupMock: func(m *mock.MockWSMANer) {
+				m.EXPECT().SetupWsmanClient("admin", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(hbcMaxAttempts)
+				m.EXPECT().GetGeneralSettings().Return(general.Response{}, errors.New("EOF")).Times(hbcMaxAttempts)
+			},
+			wantErr: true,
+		},
+		{
+			name: "fails immediately on client setup error",
+			setupMock: func(m *mock.MockWSMANer) {
+				m.EXPECT().SetupWsmanClient("admin", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("setup failed"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockWSMAN := mock.NewMockWSMANer(ctrl)
+			tt.setupMock(mockWSMAN)
+
+			service := &LocalActivationService{
+				wsman:  mockWSMAN,
+				config: LocalActivationConfig{AMTPassword: "password123"},
+			}
+
+			got, err := service.connectAdminAfterActivation(nil)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("connectAdminAfterActivation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && got.Body.GetResponse.DigestRealm != settings.Body.GetResponse.DigestRealm {
+				t.Errorf("connectAdminAfterActivation() DigestRealm = %q, want %q", got.Body.GetResponse.DigestRealm, settings.Body.GetResponse.DigestRealm)
+			}
+		})
+	}
 }
 
 // Test for getProvisioningCertObj function coverage


### PR DESCRIPTION
After StartHBC the device transitions to in-provisioning and re-arms its local TLS listener, so the first admin connection is reset (connection forcibly closed / EOF) and activation aborted with exit status 10. Retry the admin WSMAN setup and general-settings read using the existing SHBC backoff instead of failing on the first attempt.

Bump the shared firmware backoff from 2s to 3s.