### PR TITLE
fix(internal): honor firmware status on deactivate and stop-config

### DIFF
--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -194,9 +194,14 @@ func (cmd *LocalActivateCmd) handleStopConfiguration(ctx *commands.Context) erro
 		}
 	}
 	// Call StopConfiguration to clean up host-based config state
-	_, stopErr := amtCmd.StopConfiguration()
+	stopResp, stopErr := amtCmd.StopConfiguration()
 	if stopErr != nil {
 		return fmt.Errorf("failed to stop configuration: %w", stopErr)
+	}
+	// The firmware reports the real result in the response status; a non-success
+	// status must not be reported as success.
+	if stopResp.Status != amtStatusSuccess {
+		return fmt.Errorf("failed to stop configuration: firmware status %q", stopResp.Status)
 	}
 
 	if ctx.JsonOutput {
@@ -710,9 +715,15 @@ func (service *LocalActivationService) setupMEBxAndCommit() error {
 func (service *LocalActivationService) stopConfigOnFailure() {
 	log.Info("Activation failed; putting device back to pre-provisioning state")
 
-	_, err := service.amtCommand.StopConfiguration()
+	stopResp, err := service.amtCommand.StopConfiguration()
 	if err != nil {
 		log.Error("Failed to stop configuration: ", err)
+
+		return
+	}
+
+	if stopResp.Status != amtStatusSuccess {
+		log.Errorf("Failed to stop configuration: firmware status %q", stopResp.Status)
 	}
 }
 

--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -220,16 +220,17 @@ func TestNewLocalActivationService(t *testing.T) {
 
 // Mock AMT Command for testing
 type MockAMTCommand struct {
-	controlMode     int
-	changeEnabled   MockChangeEnabled
-	shouldErrorOn   string
-	unProvisionMode int
-	hbcResponses    []amt.SecureHBasedResponse
-	hbcErrors       []error
-	hbcCalls        int
-	upidValue       *upid.UPID
-	upidErr         error
-	upidCalls       int
+	controlMode      int
+	changeEnabled    MockChangeEnabled
+	shouldErrorOn    string
+	unProvisionMode  int
+	hbcResponses     []amt.SecureHBasedResponse
+	hbcErrors        []error
+	hbcCalls         int
+	upidValue        *upid.UPID
+	upidErr          error
+	upidCalls        int
+	stopConfigStatus string
 }
 type MockChangeEnabled struct {
 	amtEnabled bool
@@ -456,7 +457,11 @@ func (m *MockAMTCommand) StopConfiguration() (amt.StopConfigurationResponse, err
 		return amt.StopConfigurationResponse{}, errors.New("mock error")
 	}
 
-	return amt.StopConfigurationResponse{Status: "Success"}, nil
+	if m.stopConfigStatus != "" {
+		return amt.StopConfigurationResponse{Status: m.stopConfigStatus}, nil
+	}
+
+	return amt.StopConfigurationResponse{Status: "AMT_STATUS_SUCCESS"}, nil
 }
 
 func (m *MockAMTCommand) GetCiraLog() (pthi.GetCiraLogResponse, error) {
@@ -625,10 +630,11 @@ func TestLocalActivationService_enableAMT(t *testing.T) {
 // interactive prompt behavior covered in base tests.
 func TestLocalActivateCmd_handleStopConfiguration(t *testing.T) {
 	tests := []struct {
-		name          string
-		jsonOutput    bool
-		shouldErrorOn string
-		wantErr       bool
+		name             string
+		jsonOutput       bool
+		shouldErrorOn    string
+		stopConfigStatus string
+		wantErr          bool
 	}{
 		{
 			name:       "successful stop config with JSON output",
@@ -646,12 +652,19 @@ func TestLocalActivateCmd_handleStopConfiguration(t *testing.T) {
 			shouldErrorOn: "StopConfiguration",
 			wantErr:       true,
 		},
+		{
+			name:             "firmware rejects with non-success status",
+			jsonOutput:       false,
+			stopConfigStatus: "AMT_STATUS_INVALID_AMT_MODE",
+			wantErr:          true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAMT := &MockAMTCommand{
-				unProvisionMode: 2,
-				shouldErrorOn:   tt.shouldErrorOn,
+				unProvisionMode:  2,
+				shouldErrorOn:    tt.shouldErrorOn,
+				stopConfigStatus: tt.stopConfigStatus,
 			}
 
 			cmd := &LocalActivateCmd{

--- a/pkg/pthi/commands.go
+++ b/pkg/pthi/commands.go
@@ -314,6 +314,15 @@ func (pthi Command) Unprovision() (state int, err error) {
 
 	binary.Read(buf2, binary.LittleEndian, &response.State)
 
+	// The firmware reports the real result in the response header Status, not in
+	// the State payload. A non-success status (e.g. AMT_STATUS_INVALID_AMT_MODE,
+	// returned when a HECI unprovision is attempted on an ACM device) must not be
+	// reported as success — otherwise callers see State==0 and assume the device
+	// was deactivated when the firmware actually rejected the request.
+	if response.Header.Status != AMT_STATUS_SUCCESS {
+		return int(response.State), fmt.Errorf("unprovision failed: %s", response.Header.Status)
+	}
+
 	return int(response.State), nil
 }
 

--- a/pkg/pthi/commands.go
+++ b/pkg/pthi/commands.go
@@ -319,8 +319,14 @@ func (pthi Command) Unprovision() (state int, err error) {
 	// returned when a HECI unprovision is attempted on an ACM device) must not be
 	// reported as success — otherwise callers see State==0 and assume the device
 	// was deactivated when the firmware actually rejected the request.
+	//
+	// Return -1 rather than the payload state, matching every other failure exit
+	// in this file: a caller that ignores err then sees an obviously invalid
+	// state instead of a plausible 0. The message carries the symbolic and the
+	// numeric status — Status.String() renders unrecognized codes generically —
+	// plus the reported state, so an unknown rejection is still diagnosable.
 	if response.Header.Status != AMT_STATUS_SUCCESS {
-		return int(response.State), fmt.Errorf("unprovision failed: %s", response.Header.Status)
+		return -1, fmt.Errorf("unprovision failed: %s (0x%x), reported state %d", response.Header.Status, uint32(response.Header.Status), response.State)
 	}
 
 	return int(response.State), nil

--- a/pkg/pthi/commands_test.go
+++ b/pkg/pthi/commands_test.go
@@ -183,6 +183,25 @@ func TestUnprovision(t *testing.T) {
 	assert.Equal(t, 0, result)
 }
 
+func TestUnprovisionFirmwareRejects(t *testing.T) {
+	numBytes = GET_REQUEST_SIZE + 4
+	// Firmware rejects a HECI unprovision on an ACM device with
+	// AMT_STATUS_INVALID_AMT_MODE in the response header status. The State
+	// payload is still 0, so the status is the only signal of failure.
+	prepareMessage := UnprovisionResponse{
+		Header: ResponseMessageHeader{Status: AMT_STATUS_INVALID_AMT_MODE},
+	}
+
+	var bin_buf bytes.Buffer
+
+	binary.Write(&bin_buf, binary.LittleEndian, prepareMessage)
+	message = bin_buf.Bytes()
+
+	_, err := pthi.Unprovision()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AMT_STATUS_INVALID_AMT_MODE")
+}
+
 func TestGetCodeVersions(t *testing.T) {
 	numBytes = GET_REQUEST_SIZE
 	prepareMessage := GetCodeVersionsResponse{

--- a/pkg/pthi/commands_test.go
+++ b/pkg/pthi/commands_test.go
@@ -197,9 +197,14 @@ func TestUnprovisionFirmwareRejects(t *testing.T) {
 	binary.Write(&bin_buf, binary.LittleEndian, prepareMessage)
 	message = bin_buf.Bytes()
 
-	_, err := pthi.Unprovision()
+	state, err := pthi.Unprovision()
 	assert.Error(t, err)
+	// -1, not the payload state: a caller that ignores err must not read a
+	// plausible-looking 0 out of a rejected unprovision.
+	assert.Equal(t, -1, state)
 	assert.Contains(t, err.Error(), "AMT_STATUS_INVALID_AMT_MODE")
+	assert.Contains(t, err.Error(), "0x3")
+	assert.Contains(t, err.Error(), "reported state 0")
 }
 
 func TestGetCodeVersions(t *testing.T) {


### PR DESCRIPTION
## Fixed bugs:
[part1] of #1458
rest of the fix of https://github.com/device-management-toolkit/rpc-go/issues/1458 in [PR1463 ](https://github.com/device-management-toolkit/rpc-go/pull/1463) [Part2]

## Problem

The HECI `Unprovision` and `StopConfiguration` paths read only the response
**payload** and ignored the firmware **result status**, so a firmware rejection
was reported as success — a false-success class affecting deactivation.

- **`Unprovision` (`pkg/pthi/commands.go`)** read only the `State` payload. On an
  ACM device the firmware rejects a HECI unprovision with
  `AMT_STATUS_INVALID_AMT_MODE` (status 3) **while still returning `State=0`**, so
  callers reported "Device deactivated" when the firmware had refused.
- **`StopConfiguration`** carries its result only in the response status string,
  and both callers ignored it: `handleStopConfiguration` (the user-facing
  `activate --stopConfig`) printed success even on rejection, and
  `stopConfigOnFailure` silently treated a rejected recovery as done.

## Fix

- `pkg/pthi/commands.go` — check `response.Header.Status` and return an error on
  any non-success code. CCM deactivation now surfaces real failures; the ACM
  rejection is no longer masked.
- `internal/commands/activate/local.go` — both `StopConfiguration` callers check
  the response status against `AMT_STATUS_SUCCESS` (the pattern
  `StartConfigurationHBased` already follows) and propagate a non-success status
  as an error.
- Corrected the test mock to return the real firmware status string.

### `fix(pthi): return an invalid state when firmware rejects unprovision` (`d6c3f08`)
Review follow-up. The rejection path returned the `State` payload alongside the
error. Every other failure exit in that file returns `-1`, and
`AMTCommand.Unprovision` does the same, so a caller that ignored `err` read a
plausible `0` out of a rejected unprovision and could still conclude the device
had been deactivated. Now returns `-1`, and the message carries the symbolic
status, the numeric status and the reported state — `Status.String()` renders
unrecognized codes generically, so an unknown rejection stays diagnosable.

## Scope note

An ACM device cannot be unprovisioned over HECI at all (the firmware forbids it);
ACM local deactivation on a mutual-TLS-enforced port remains a firmware
limitation handled out of band (profile TLS mode, or remote/RPS). PR2's
in-provisioning HECI-fallback (`e3482f6`) handles the specific wedged half-state,
and PR4's `92180bc` completes it for a device wedged mid-ACM-configuration.

## Acceptance

A non-success firmware status on `Unprovision`/`StopConfiguration` surfaces as an
error (no false "deactivated"), and the rejection returns an invalid state rather
than a plausible one. A successful deactivate still succeeds.

```
 internal/commands/activate/local.go      | 15 +++++++++++++--
 internal/commands/activate/local_test.go | 47 +++++++++++++++++++++-----------
 pkg/pthi/commands.go                     | 15 +++++++++++++
 pkg/pthi/commands_test.go                | 24 ++++++++++++++++++
 4 files changed, 82 insertions(+), 19 deletions(-)
```
