### PR TITLE
fix: local activation/deactivation reports the correct outcome

### DIFF
--- a/internal/commands/activate/commit_test.go
+++ b/internal/commands/activate/commit_test.go
@@ -27,6 +27,15 @@ func TestIsConnectionResetErr(t *testing.T) {
 		{"nil", nil, false},
 		{"bare EOF", io.EOF, true},
 		{"connection reset", syscall.ECONNRESET, true},
+		{"bare unexpected EOF", io.ErrUnexpectedEOF, true},
+		// The exact error observed on AMT 20.0.5 (ISM) over LME. This, not the bare
+		// io.EOF above, is what the transport produces on real hardware; the io.EOF
+		// case is retained only because it is cheap to keep matching. Recovery
+		// normally still works because the LME retry is refused and
+		// apf.ErrChannelOpenFailure surfaces instead — when the retry succeeds in
+		// reopening the channel, this error arrives on its own and missing it
+		// reports a device that did activate as a failure.
+		{"url.Error wrapping the LME transport's unexpected EOF", &url.Error{Op: "Post", URL: "https://127.0.0.1:16993/wsman", Err: fmt.Errorf("read response over AMT TLS: %w", io.ErrUnexpectedEOF)}, true},
 		{"url.Error wrapping EOF (the observed CommitChanges symptom)", &url.Error{Op: "Post", URL: "https://localhost:16993/wsman", Err: io.EOF}, true},
 		{"APF channel-open failure (port stack restarting on LME retry)", fmt.Errorf("%w, reason code: 2", apf.ErrChannelOpenFailure), true},
 		{"url.Error wrapping APF channel-open failure", &url.Error{Op: "Post", URL: "https://localhost:16993/wsman", Err: fmt.Errorf("%w, reason code: 2", apf.ErrChannelOpenFailure)}, true},

--- a/internal/commands/activate/commit_test.go
+++ b/internal/commands/activate/commit_test.go
@@ -1,0 +1,164 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2024
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package activate
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"syscall"
+	"testing"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/apf"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
+	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+func TestIsConnectionResetErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bare EOF", io.EOF, true},
+		{"connection reset", syscall.ECONNRESET, true},
+		{"url.Error wrapping EOF (the observed CommitChanges symptom)", &url.Error{Op: "Post", URL: "https://localhost:16993/wsman", Err: io.EOF}, true},
+		{"APF channel-open failure (port stack restarting on LME retry)", fmt.Errorf("%w, reason code: 2", apf.ErrChannelOpenFailure), true},
+		{"url.Error wrapping APF channel-open failure", &url.Error{Op: "Post", URL: "https://localhost:16993/wsman", Err: fmt.Errorf("%w, reason code: 2", apf.ErrChannelOpenFailure)}, true},
+		{"unrelated error", errors.New("some other failure"), false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isConnectionResetErr(tt.err); got != tt.want {
+				t.Errorf("isConnectionResetErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCommitActivation_ConnectionResetButActivated reproduces the AMT20 TLS log:
+// CommitChanges returns "Post .../wsman: EOF" because the firmware restarts the
+// LMS port stack mid-response, yet the device is actually provisioned. The commit
+// must be treated as a success, not a failure.
+func TestCommitActivation_ConnectionResetButActivated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, &url.Error{Op: "Post", URL: "https://localhost:16993/wsman", Err: io.EOF})
+
+	service := &LocalActivationService{
+		wsman:      mockWSMAN,
+		amtCommand: &MockAMTCommand{controlMode: AMTControlModeACM},
+	}
+
+	if err := service.commitActivation(); err != nil {
+		t.Fatalf("commitActivation() error = %v, want nil (device is provisioned)", err)
+	}
+}
+
+// TestCommitActivation_ChannelOpenFailureButActivated reproduces the AMT20 TLS
+// log: CommitChanges is cut off by an EOF, the LME transport resets HECI and
+// retries, and the retry hits APF_CHANNEL_OPEN_FAILURE (reason code 2) because
+// the firmware port stack is still restarting. That channel-open failure — not
+// the EOF — is the error that surfaces, yet the device is actually provisioned,
+// so the commit must be treated as a success rather than rolled back.
+func TestCommitActivation_ChannelOpenFailureButActivated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, &url.Error{
+			Op:  "Post",
+			URL: "https://localhost:16993/wsman",
+			Err: fmt.Errorf("%w, reason code: 2", apf.ErrChannelOpenFailure),
+		})
+
+	service := &LocalActivationService{
+		wsman:      mockWSMAN,
+		amtCommand: &MockAMTCommand{controlMode: AMTControlModeACM},
+	}
+
+	if err := service.commitActivation(); err != nil {
+		t.Fatalf("commitActivation() error = %v, want nil (device is provisioned)", err)
+	}
+}
+
+// TestCommitActivation_ConnectionResetStillPreProvisioning verifies that a dropped
+// connection with the device still in pre-provisioning is a genuine failure.
+func TestCommitActivation_ConnectionResetStillPreProvisioning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, io.EOF)
+
+	service := &LocalActivationService{
+		wsman:      mockWSMAN,
+		amtCommand: &MockAMTCommand{controlMode: AMTControlModePreProvisioning},
+	}
+
+	if err := service.commitActivation(); !errors.Is(err, io.EOF) {
+		t.Fatalf("commitActivation() error = %v, want io.EOF (still pre-provisioning)", err)
+	}
+}
+
+// TestCommitActivation_NonResetErrorReturnedVerbatim verifies an application-level
+// CommitChanges error (e.g. 2057) is returned unchanged without consulting HECI,
+// so callers like setupMEBxAndCommit can still branch on it.
+func TestCommitActivation_NonResetErrorReturnedVerbatim(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	dataMissing := errors.New("CommitChanges failed: error code 2057")
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, dataMissing)
+
+	// GetControlMode must NOT be consulted for a non-reset error; MockAMTCommand
+	// would return a zero control mode, but we assert the original error survives.
+	service := &LocalActivationService{
+		wsman:      mockWSMAN,
+		amtCommand: &MockAMTCommand{controlMode: AMTControlModeACM},
+	}
+
+	err := service.commitActivation()
+	if !errors.Is(err, dataMissing) {
+		t.Fatalf("commitActivation() error = %v, want the original 2057 error", err)
+	}
+}
+
+// TestCommitActivation_Success covers the ordinary path where CommitChanges
+// returns no error.
+func TestCommitActivation_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, nil)
+
+	service := &LocalActivationService{
+		wsman:      mockWSMAN,
+		amtCommand: &MockAMTCommand{controlMode: AMTControlModeACM},
+	}
+
+	if err := service.commitActivation(); err != nil {
+		t.Fatalf("commitActivation() error = %v, want nil", err)
+	}
+}

--- a/internal/commands/activate/commit_test.go
+++ b/internal/commands/activate/commit_test.go
@@ -57,8 +57,11 @@ func TestCommitActivation_ConnectionResetButActivated(t *testing.T) {
 		Return(setupandconfiguration.Response{}, &url.Error{Op: "Post", URL: "https://localhost:16993/wsman", Err: io.EOF})
 
 	service := &LocalActivationService{
-		wsman:      mockWSMAN,
-		amtCommand: &MockAMTCommand{controlMode: AMTControlModeACM},
+		wsman: mockWSMAN,
+		amtCommand: &MockAMTCommand{
+			controlMode:       AMTControlModeACM,
+			provisioningState: provisioningStatePostProvisioning,
+		},
 	}
 
 	if err := service.commitActivation(); err != nil {
@@ -86,12 +89,67 @@ func TestCommitActivation_ChannelOpenFailureButActivated(t *testing.T) {
 		})
 
 	service := &LocalActivationService{
-		wsman:      mockWSMAN,
-		amtCommand: &MockAMTCommand{controlMode: AMTControlModeACM},
+		wsman: mockWSMAN,
+		amtCommand: &MockAMTCommand{
+			controlMode:       AMTControlModeACM,
+			provisioningState: provisioningStatePostProvisioning,
+		},
 	}
 
 	if err := service.commitActivation(); err != nil {
 		t.Fatalf("commitActivation() error = %v, want nil (device is provisioned)", err)
+	}
+}
+
+// TestCommitActivation_ConnectionResetStillInProvisioning verifies that a control
+// mode alone is not accepted as proof the commit landed. A device that halted
+// mid-activation reports ACM while still sitting in provisioning state 1; that is
+// a genuine failure and must not be reported as a successful activation.
+func TestCommitActivation_ConnectionResetStillInProvisioning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, io.EOF)
+
+	service := &LocalActivationService{
+		wsman: mockWSMAN,
+		amtCommand: &MockAMTCommand{
+			controlMode:       AMTControlModeACM,
+			provisioningState: 1,
+		},
+	}
+
+	if err := service.commitActivation(); !errors.Is(err, io.EOF) {
+		t.Fatalf("commitActivation() error = %v, want io.EOF (still in provisioning)", err)
+	}
+}
+
+// TestCommitActivation_ProvisioningStateUnreadableFallsBackToControlMode verifies
+// the escape hatch: firmware that cannot report a provisioning state must not turn
+// genuine activations into failures, so an unreadable state falls back to the
+// control-mode decision.
+func TestCommitActivation_ProvisioningStateUnreadableFallsBackToControlMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+	mockWSMAN.EXPECT().
+		CommitChanges().
+		Return(setupandconfiguration.Response{}, io.EOF)
+
+	service := &LocalActivationService{
+		wsman: mockWSMAN,
+		amtCommand: &MockAMTCommand{
+			controlMode:   AMTControlModeACM,
+			shouldErrorOn: "GetProvisioningState",
+		},
+	}
+
+	if err := service.commitActivation(); err != nil {
+		t.Fatalf("commitActivation() error = %v, want nil (state unreadable, mode says provisioned)", err)
 	}
 }
 

--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -825,10 +825,24 @@ func (service *LocalActivationService) commitActivation() error {
 //
 //   - EOF / connection reset / use-of-closed-connection: the response was cut
 //     off while in flight.
+//   - io.ErrUnexpectedEOF: the same cut-off, reported as a short read because it
+//     landed part-way through a TLS record. This — not a bare io.EOF — is what
+//     the LME transport actually produces on AMT19+ ("read response over AMT
+//     TLS: unexpected EOF"); across every captured AMT20/21 LME run a clean
+//     io.EOF never appeared. It is a distinct sentinel, so errors.Is against
+//     io.EOF does not match it. internal/local/amt already pairs the two in
+//     isTransientLMEError and lmsUpButUnready.
 //   - apf.ErrChannelOpenFailure: after the initial cut-off, the LME transport
-//     resets HECI and retries, but the firmware refuses the fresh APF channel
-//     (APF_CHANNEL_OPEN_FAILURE) while the port stack is still restarting, so
-//     this — not the EOF — is the error that ultimately surfaces to the caller.
+//     resets HECI and retries. Usually the firmware refuses the fresh APF
+//     channel (APF_CHANNEL_OPEN_FAILURE) while the port stack is still
+//     restarting, and that is the error the caller ends up seeing.
+//
+// The last two interact, which is what makes the io.ErrUnexpectedEOF case easy
+// to miss: while the retry keeps being refused, ErrChannelOpenFailure masks the
+// short read and recovery works. Only when the retry does reopen the channel —
+// new APF channel, fresh TLS handshake — and the response is still lost does
+// io.ErrUnexpectedEOF reach the caller alone. Matching only one of the two
+// therefore passes on most hardware runs and fails on a few.
 //
 // The net/http error is wrapped in *url.Error and apf wraps its sentinel with
 // %w, but errors.Is unwraps through both.
@@ -838,6 +852,7 @@ func isConnectionResetErr(err error) bool {
 	}
 
 	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, syscall.ECONNRESET) ||
 		errors.Is(err, net.ErrClosed) ||
 		errors.Is(err, apf.ErrChannelOpenFailure)

--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -92,6 +92,13 @@ const (
 	AMTControlModeACM = 2
 )
 
+// provisioningStatePostProvisioning is the HECI provisioning-state value for a
+// device that finished activation. A control mode alone is not proof of success:
+// a device that halted mid-activation reports ACM/CCM while still sitting in
+// "in provisioning" (state 1), so activation must confirm this state before
+// calling a dropped CommitChanges a success.
+const provisioningStatePostProvisioning = 2
+
 const (
 	activationModeCCM = "CCM"
 	activationModeACM = "ACM"
@@ -787,9 +794,19 @@ func (service *LocalActivationService) commitActivation() error {
 	for attempt := 1; attempt <= commitPortRestartAttempts; attempt++ {
 		mode, modeErr := service.amtCommand.GetControlMode()
 		if modeErr == nil && mode != AMTControlModePreProvisioning {
-			log.Info("Device is provisioned; CommitChanges succeeded despite the dropped connection.")
+			// A control mode alone is not proof the commit landed: a device that
+			// halted mid-activation reports ACM/CCM while still sitting "in
+			// provisioning". Require post-provisioning before calling it a success.
+			// If the state cannot be read at all, fall back to the control mode
+			// rather than failing an activation that most likely succeeded.
+			state, stateErr := service.amtCommand.GetProvisioningState()
+			if stateErr != nil || state == provisioningStatePostProvisioning {
+				log.Info("Device is provisioned; CommitChanges succeeded despite the dropped connection.")
 
-			return nil
+				return nil
+			}
+
+			log.Debugf("Control mode %d is set but the device is still in provisioning state %d; activation has not completed", mode, state)
 		}
 
 		if attempt < commitPortRestartAttempts {

--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -18,9 +18,13 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"strings"
+	"syscall"
 	"time"
 
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/apf"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/certs"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
@@ -96,6 +100,16 @@ const (
 	jsonKeyFriendly   = "friendly_name"
 	jsonValueSuccess  = "success"
 	amtStatusSuccess  = "AMT_STATUS_SUCCESS"
+)
+
+const (
+	// commitPortRestartAttempts bounds how many times activation re-reads the AMT
+	// control mode after CommitChanges drops its connection, to confirm whether
+	// the commit completed during the firmware port-stack restart.
+	commitPortRestartAttempts = 3
+	// commitPortRestartDelay is the wait between control-mode re-reads while the
+	// firmware finishes the post-commit port-stack restart (milliseconds).
+	commitPortRestartDelay = 1000
 )
 
 func (m ActivationMode) String() string {
@@ -666,10 +680,8 @@ func (service *LocalActivationService) setupMEBxAndCommit() error {
 		return nil
 	}
 	// No MEBx password provided — try CommitChanges directly
-	result, err := service.wsman.CommitChanges()
+	err := service.commitActivation()
 	if err == nil {
-		log.Debug(result)
-
 		return nil
 	}
 
@@ -740,16 +752,78 @@ func (service *LocalActivationService) setMEBxAndCommit(mebxPassword string) err
 
 	log.Info("Successfully updated MEBx Password.")
 
-	result, err := service.wsman.CommitChanges()
-	if err != nil {
+	if err := service.commitActivation(); err != nil {
 		log.Error(err.Error())
 
 		return utils.ActivationFailed
 	}
 
-	log.Debug(result)
-
 	return nil
+}
+
+// commitActivation calls CommitChanges to finalize activation. CommitChanges is
+// the step where the firmware restarts the AMT/LMS local port stack; on
+// TLS-enforced platforms (AMT19+) that restart tears down the LMS relay
+// connection while the HTTP response is still in flight, so the call returns a
+// connection-drop error (EOF / reset) even though the commit already took
+// effect. Substring-matching the transport error would be brittle, so instead we
+// confirm the authoritative firmware state: re-read the control mode over HECI
+// and, if the device is now provisioned, treat the commit as the success it was.
+// Any other error (or a device still in pre-provisioning) is a genuine failure.
+func (service *LocalActivationService) commitActivation() error {
+	result, err := service.wsman.CommitChanges()
+	if err == nil {
+		log.Debug(result)
+
+		return nil
+	}
+
+	if !isConnectionResetErr(err) {
+		return err
+	}
+
+	log.Warnf("CommitChanges connection dropped (%v); the firmware may be restarting the local port stack. Verifying activation state over HECI...", err)
+
+	for attempt := 1; attempt <= commitPortRestartAttempts; attempt++ {
+		mode, modeErr := service.amtCommand.GetControlMode()
+		if modeErr == nil && mode != AMTControlModePreProvisioning {
+			log.Info("Device is provisioned; CommitChanges succeeded despite the dropped connection.")
+
+			return nil
+		}
+
+		if attempt < commitPortRestartAttempts {
+			time.Sleep(commitPortRestartDelay * time.Millisecond)
+		}
+	}
+
+	// Still pre-provisioning (or control mode unreadable): the commit really failed.
+	return err
+}
+
+// isConnectionResetErr reports whether err is a dropped/reset transport
+// connection rather than an application-level failure. These are the symptoms of
+// the LMS relay being torn down mid-response by the post-commit firmware
+// port-stack restart:
+//
+//   - EOF / connection reset / use-of-closed-connection: the response was cut
+//     off while in flight.
+//   - apf.ErrChannelOpenFailure: after the initial cut-off, the LME transport
+//     resets HECI and retries, but the firmware refuses the fresh APF channel
+//     (APF_CHANNEL_OPEN_FAILURE) while the port stack is still restarting, so
+//     this — not the EOF — is the error that ultimately surfaces to the caller.
+//
+// The net/http error is wrapped in *url.Error and apf wraps its sentinel with
+// %w, but errors.Is unwraps through both.
+func isConnectionResetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, apf.ErrChannelOpenFailure)
 }
 
 // isDataMissingError checks if an error is PT_STATUS_DATA_MISSING (error code 2057).

--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -231,6 +231,10 @@ type MockAMTCommand struct {
 	upidErr          error
 	upidCalls        int
 	stopConfigStatus string
+	// provisioningState is what GetProvisioningState reports: 0 pre, 1 in
+	// provisioning, 2 post. Tests that expect a completed activation must set
+	// this to provisioningStatePostProvisioning.
+	provisioningState int
 }
 type MockChangeEnabled struct {
 	amtEnabled bool
@@ -253,7 +257,7 @@ func (m *MockAMTCommand) GetProvisioningState() (int, error) {
 		return 0, errors.New("mock error")
 	}
 
-	return 0, nil
+	return m.provisioningState, nil
 }
 
 func (m *MockAMTCommand) GetChangeEnabled() (amt.ChangeEnabledResponse, error) {

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -433,8 +433,18 @@ func (cmd *DeactivateCmd) provisioningHalted(ctx *Context) bool {
 func (cmd *DeactivateCmd) recoverInProvisioningOverHECI(ctx *Context, wsmanErr error) error {
 	log.Warnf("WSMAN deactivate failed while device is in provisioning (%v); recovering over HECI", wsmanErr)
 
-	if _, err := ctx.AMTCommand.Unprovision(); err != nil {
+	// Unprovision reports failure through the state in the firmware response as
+	// well as through err — deactivateCCM below checks both. Gating on err alone
+	// would report a firmware-rejected unprovision as a successful deactivation.
+	state, err := ctx.AMTCommand.Unprovision()
+
+	switch {
+	case err != nil:
 		log.Error("Status: Unable to deactivate over HECI ", err)
+
+		return utils.UnableToDeactivate
+	case state != 0:
+		log.Errorf("Status: Unable to deactivate over HECI; firmware reported state %d", state)
 
 		return utils.UnableToDeactivate
 	}

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -25,6 +25,13 @@ const (
 	ControlModeACM = 2
 )
 
+// provisioningStateInProvisioning is the HECI provisioning-state value for a
+// device that began but never finished activation: a control mode is set but the
+// flow never reached "provisioned". Such a device exposes a mutual-TLS port on
+// :16993 that rpc has no client certificate for, so a WSMAN deactivate can never
+// complete — it must be recovered over HECI instead.
+const provisioningStateInProvisioning = 1
+
 // setupTLSConfig creates TLS configuration if local TLS is enforced
 func (cmd *DeactivateCmd) setupTLSConfig(ctx *Context) *tls.Config {
 	tlsConfig := &tls.Config{}
@@ -352,7 +359,7 @@ func (cmd *DeactivateCmd) executeLocalDeactivate(ctx *Context) error {
 
 		return cmd.deactivateCCM(ctx)
 	case ControlModeACM:
-		return cmd.deactivateACM()
+		return cmd.deactivateACM(ctx)
 	default:
 		log.Error("Deactivation failed. Device control mode: " + utils.InterpretControlMode(controlMode))
 
@@ -361,13 +368,13 @@ func (cmd *DeactivateCmd) executeLocalDeactivate(ctx *Context) error {
 }
 
 // deactivateACM handles ACM mode deactivation
-func (cmd *DeactivateCmd) deactivateACM() error {
+func (cmd *DeactivateCmd) deactivateACM(ctx *Context) error {
 	// Execute deactivation operation
 	if cmd.PartialUnprovision {
 		return cmd.executePartialUnprovision()
 	}
 
-	return cmd.executeFullUnprovision()
+	return cmd.executeFullUnprovision(ctx)
 }
 
 // executePartialUnprovision performs partial unprovision operation
@@ -385,10 +392,49 @@ func (cmd *DeactivateCmd) executePartialUnprovision() error {
 }
 
 // executeFullUnprovision performs full unprovision operation
-func (cmd *DeactivateCmd) executeFullUnprovision() error {
+func (cmd *DeactivateCmd) executeFullUnprovision(ctx *Context) error {
 	_, err := cmd.WSMan.Unprovision(1)
-	if err != nil {
-		log.Error("Status: Unable to deactivate ", err)
+	if err == nil {
+		log.Info("Status: Device deactivated")
+
+		return nil
+	}
+
+	// A device that halted mid-activation ("in provisioning") exposes a mutual-TLS
+	// port on :16993 that rpc has no client certificate for, so the WSMAN
+	// Unprovision above can never complete (it fails at the TLS handshake). That
+	// stuck half-state is recoverable over HECI instead, so fall back to it rather
+	// than leaving the device permanently wedged.
+	if cmd.provisioningHalted(ctx) {
+		return cmd.recoverInProvisioningOverHECI(ctx, err)
+	}
+
+	log.Error("Status: Unable to deactivate ", err)
+
+	return utils.UnableToDeactivate
+}
+
+// provisioningHalted reports whether the device is stuck "in provisioning" — a
+// control mode is set but activation never completed. The provisioning state is
+// read over HECI, which is unaffected by the TLS-port state that blocks WSMAN.
+func (cmd *DeactivateCmd) provisioningHalted(ctx *Context) bool {
+	state, stateErr := ctx.AMTCommand.GetProvisioningState()
+	if stateErr != nil {
+		log.Debugf("Could not read provisioning state to classify deactivate failure: %v", stateErr)
+
+		return false
+	}
+
+	return state == provisioningStateInProvisioning
+}
+
+// recoverInProvisioningOverHECI unprovisions a device stuck "in provisioning"
+// using HECI, bypassing the WSMAN/TLS path that cannot complete in that state.
+func (cmd *DeactivateCmd) recoverInProvisioningOverHECI(ctx *Context, wsmanErr error) error {
+	log.Warnf("WSMAN deactivate failed while device is in provisioning (%v); recovering over HECI", wsmanErr)
+
+	if _, err := ctx.AMTCommand.Unprovision(); err != nil {
+		log.Error("Status: Unable to deactivate over HECI ", err)
 
 		return utils.UnableToDeactivate
 	}

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
@@ -837,5 +838,102 @@ func TestDeactivateCmd_setupTLSConfig_ControlModePaths(t *testing.T) {
 		assert.NotNil(t, tlsConfig)
 		assert.True(t, tlsConfig.InsecureSkipVerify)
 		assert.NotNil(t, tlsConfig.VerifyPeerCertificate)
+	})
+}
+
+// TestDeactivateCmd_ExecuteFullUnprovision covers the ACM full-unprovision path,
+// including the HECI recovery fallback for a device stuck "in provisioning" whose
+// mutual-TLS :16993 port blocks the WSMAN Unprovision (the AMT21 cleanup log).
+func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
+	tlsCertRequired := &url.Error{
+		Op:  "Post",
+		URL: "https://localhost:16993/wsman",
+		Err: errors.New("remote error: tls: certificate required"),
+	}
+
+	t.Run("WSMAN unprovision succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, nil)
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("in-provisioning device recovers over HECI when WSMAN fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, tlsCertRequired)
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
+		mockAMT.EXPECT().Unprovision().Return(0, nil)
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.NoError(t, err)
+	})
+
+	t.Run("provisioned device does not fall back to HECI", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, errors.New("boom"))
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(2, nil) // post-provisioning
+		// No Unprovision() expectation: HECI fallback must not run.
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.ErrorIs(t, err, utils.UnableToDeactivate)
+	})
+
+	t.Run("HECI recovery failure surfaces UnableToDeactivate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, tlsCertRequired)
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
+		mockAMT.EXPECT().Unprovision().Return(-1, errors.New("invalid AMT mode"))
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.ErrorIs(t, err, utils.UnableToDeactivate)
+	})
+
+	t.Run("unreadable provisioning state keeps the WSMAN failure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, errors.New("boom"))
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(-1, errors.New("HECI busy"))
+		// No Unprovision() expectation: cannot confirm the half-state, so no fallback.
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.ErrorIs(t, err, utils.UnableToDeactivate)
 	})
 }

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -883,6 +883,25 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("HECI unprovision reporting a non-zero state is not a success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, tlsCertRequired)
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
+		// Firmware rejected the request through the response state, not through err.
+		mockAMT.EXPECT().Unprovision().Return(1, nil)
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.ErrorIs(t, err, utils.UnableToDeactivate)
+	})
+
 	t.Run("provisioned device does not fall back to HECI", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -33,6 +33,32 @@ type LMSConnection struct {
 // client Finished — and we must not tear the tunnel down for those).
 var ErrLMSReadTimeoutNoData = errors.New("lms read timeout with no data")
 
+// plainFirstByteTimeout bounds how long the non-TLS-tunnel LMS relay waits for
+// the first byte of AMT's response to a WSMAN request. Unlike the TLS tunnel,
+// the plain relay is strict request/response: every WSMAN message AMT receives
+// produces exactly one HTTP response, so there is no legitimate "quiet round"
+// to yield on — we must wait for the reply. The activating IPS_HostBasedSetup
+// Setup runs provisioning crypto before answering and its first byte can land
+// ~1s out (hardware-validated on AMT16/AMT18; the same near-1s ceiling drives
+// lmeTunnelFirstByteTimeout and HeciReadTimeout), so a 3s window gives ~3x
+// margin while staying under the executor's non-tunnel AMTResponseTimeout (4s)
+// budget so the reply is delivered before the response context aborts. The
+// earlier 500ms window clipped the Setup response: the read timed out empty,
+// the relay closed the socket, RPS never saw the reply, then retried Setup
+// against an already-activated device and reported "Failed to activate."
+const plainFirstByteTimeout = 3 * time.Second
+
+// tlsFirstByteTimeout is the TLS-tunnel analog: kept short (well below RPS's
+// per-operation budget) so a legitimately-silent TLS 1.3 handshake round
+// yields promptly via ErrLMSReadTimeoutNoData instead of stalling the tunnel.
+const tlsFirstByteTimeout = 2 * time.Second
+
+// plainSubsequentReadTimeout is the idle gap, after the first response byte has
+// arrived on the plain relay, used to detect the end of AMT's chunked HTTP
+// response. AMT streams the reply contiguously over the loopback socket, so a
+// short idle window bounds per-round latency without truncating the body.
+const plainSubsequentReadTimeout = 100 * time.Millisecond
+
 func NewLMSConnection(address, port string, useTls bool, data chan []byte, errors chan error, mode int, skipCertCheck bool) *LMSConnection {
 	lms := &LMSConnection{
 		address:       address,
@@ -114,28 +140,38 @@ func (lms *LMSConnection) Close() error {
 
 // Listen reads data from the LMS socket connection.
 //
-// In TLS-tunnel mode the LMS connection is persistent across multiple tls_data
-// round-trips. TLS 1.3 has handshake rounds that legitimately produce zero
-// AMT-side bytes (e.g. immediately after our client Finished). To keep those
-// quiet rounds from stalling the tunnel and from being misread as a dead
-// connection, we use a short first-byte timeout (2s, well below RPS's
-// per-operation budget) and signal "silence before first byte" via a typed
-// ErrLMSReadTimeoutNoData on the errors channel. The executor treats that as
-// a non-fatal continuation in tunnel mode. We also skip the trailing
-// `lms.data <- buf` send for that case so callers can rely on the typed
-// error path instead of conflating timeout-no-data with EOF/close semantics.
-// The same skip applies when a non-timeout read error has been emitted on
-// `lms.errors`, so an empty buf is not delivered to `lms.data` afterwards
-// (which the executor would otherwise treat as a connection close).
+// The first-byte read timeout differs by mode because the two relays have
+// opposite silence semantics:
+//
+//   - Plain (non-TLS-tunnel) relay: strict request/response — every WSMAN
+//     message AMT receives yields exactly one HTTP response, so silence is not
+//     legitimate; we must wait for the reply. We use plainFirstByteTimeout (3s)
+//     so the slow activating Setup response is not clipped. A timeout with no
+//     bytes here is a genuinely unresponsive AMT and is surfaced as
+//     ErrLMSReadTimeoutNoData for the executor to handle.
+//   - TLS-tunnel mode: the connection is persistent across multiple tls_data
+//     round-trips and TLS 1.3 has handshake rounds that legitimately produce
+//     zero AMT-side bytes (e.g. immediately after our client Finished). We use
+//     a short tlsFirstByteTimeout (2s, well below RPS's per-operation budget)
+//     and signal "silence before first byte" via ErrLMSReadTimeoutNoData so
+//     the executor treats it as a non-fatal continuation and keeps the tunnel
+//     alive.
+//
+// In both modes we skip the trailing `lms.data <- buf` send when we timed out
+// with no bytes, so callers rely on the typed error path instead of conflating
+// timeout-no-data with EOF/close semantics. The same skip applies when a
+// non-timeout read error has been emitted on `lms.errors`, so an empty buf is
+// not delivered to `lms.data` afterwards (which the executor would otherwise
+// treat as a connection close).
 func (lms *LMSConnection) Listen() {
 	log.Debug("listening for lms messages...")
 
-	readTimeout := 500 * time.Millisecond
-	subsequentReadTimeout := 100 * time.Millisecond
+	readTimeout := plainFirstByteTimeout
+	subsequentReadTimeout := plainSubsequentReadTimeout
 
 	if lms.useTls {
-		readTimeout = 2 * time.Second
-		subsequentReadTimeout = 2 * time.Second
+		readTimeout = tlsFirstByteTimeout
+		subsequentReadTimeout = tlsFirstByteTimeout
 	}
 
 	buf := make([]byte, 0, 8192)

--- a/internal/lm/service_test.go
+++ b/internal/lm/service_test.go
@@ -7,6 +7,7 @@ package lm
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -97,4 +98,50 @@ func TestListen(t *testing.T) {
 
 	<-wait2
 	lms.Close() // should close client pipe
+}
+
+// TestListenPlainWaitsForDelayedResponse pins the plain-relay first-byte window
+// against regression. The activating IPS_HostBasedSetupService/Setup response
+// arrives after AMT runs its provisioning crypto — well past the old 500ms
+// read timeout. With plainFirstByteTimeout (3s) the relay must still capture
+// and forward that delayed response rather than timing out empty and closing
+// the socket (which stranded the reply, made RPS retry Setup against an
+// already-activated device, and reported "Failed to activate").
+func TestListenPlainWaitsForDelayedResponse(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	data := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	lms := &LMSConnection{
+		Connection: server,
+		useTls:     false,
+		data:       data,
+		errors:     errCh,
+	}
+
+	go lms.Listen()
+
+	// Respond well after the retired 500ms window but inside the 3s budget,
+	// mimicking AMT's slow Setup reply.
+	const afterOldTimeout = 900 * time.Millisecond
+
+	go func() {
+		time.Sleep(afterOldTimeout)
+
+		_, err := client.Write([]byte("setup-response"))
+		assert.NoError(t, err)
+
+		client.Close()
+	}()
+
+	select {
+	case got := <-data:
+		assert.Equal(t, []byte("setup-response"), got)
+	case err := <-errCh:
+		t.Fatalf("plain relay abandoned the delayed response: %v", err)
+	case <-time.After(plainFirstByteTimeout + time.Second):
+		t.Fatal("Listen did not deliver the delayed response within the plain first-byte window")
+	}
 }

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -244,6 +244,44 @@ func (e Executor) HandleInterrupt() {
 }
 
 // HandleDataFromRPS processes one RPS message and returns true when activation should stop.
+// lmsErrorClass categorizes an error surfaced on the LMS/LME errors channel so
+// the relay loop can decide whether to keep polling, treat the round as a
+// benign quiet round, or fail the activation.
+type lmsErrorClass int
+
+const (
+	// lmsErrorFatal is a genuine LMS/LME error that fails the activation (or, in
+	// TLS-tunnel mode, triggers a connection reset).
+	lmsErrorFatal lmsErrorClass = iota
+	// lmsErrorPoll is the normal HECI driver read timeout seen while polling for
+	// data; the loop should keep waiting.
+	lmsErrorPoll
+	// lmsErrorQuietRound is a first-byte read timeout with no bytes. In
+	// TLS-tunnel mode this is a legitimate quiet round (a TLS 1.3 handshake
+	// round after our client Finished, where AMT correctly stays silent) and we
+	// keep the tunnel alive. On the plain relay — where lm.Listen now waits a
+	// full plainFirstByteTimeout (3s), long enough for even the slow activating
+	// Setup response — a no-byte timeout instead means AMT was genuinely
+	// unresponsive for the whole window; we still yield rather than hard-fail
+	// (matching the pre-TLS-tunnel behavior, where lm.Listen forwarded an empty
+	// buffer and the relay simply waited for the next RPS message) so a
+	// transient stall doesn't abort an otherwise-recoverable activation.
+	// Genuine read errors arrive as other error types and stay lmsErrorFatal.
+	lmsErrorQuietRound
+)
+
+// classifyLMSError maps an errors-channel value to its lmsErrorClass.
+func classifyLMSError(err error) lmsErrorClass {
+	switch {
+	case errors.Is(err, heci.ErrReadTimeout):
+		return lmsErrorPoll
+	case errors.Is(err, lm.ErrLMSReadTimeoutNoData):
+		return lmsErrorQuietRound
+	default:
+		return lmsErrorFatal
+	}
+}
+
 func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 	msg, err := e.server.ProcessMessage(dataFromServer)
 	if err != nil {
@@ -454,24 +492,18 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 			return false
 		case errFromLMS := <-e.errors:
 			if errFromLMS != nil {
-				// HECI read timeout is expected while polling for data.
-				if errors.Is(errFromLMS, heci.ErrReadTimeout) {
+				switch classifyLMSError(errFromLMS) {
+				case lmsErrorPoll:
+					// HECI read timeout is expected while polling for data.
 					log.Debug("heci read timeout (normal driver timeout, not an error)")
 
 					continue
-				}
-
-				// TLS 1.3 has normal handshake rounds where LMS emits no immediate
-				// bytes (e.g. immediately after our client Finished). The LMS
-				// Listen goroutine surfaces those via ErrLMSReadTimeoutNoData; in
-				// TLS-tunnel mode treat them as a benign continuation so the
-				// connection and AMT-side TLS state stay alive and the next
-				// queued tls_data RPS message rides the same socket. Outside
-				// TLS-tunnel mode the historical fatal handling still applies.
-				if e.tlsTunnelActive && errors.Is(errFromLMS, lm.ErrLMSReadTimeoutNoData) {
-					log.Trace("No LMS data before read timeout for this TLS round-trip; continuing without connection_reset")
+				case lmsErrorQuietRound:
+					log.Trace("No LMS data before read timeout for this round-trip; continuing without failing activation")
 
 					return false
+				case lmsErrorFatal:
+					// Genuine LMS/LME error — fall through to the fatal handling below.
 				}
 
 				log.Error("LMS error: ", errFromLMS)

--- a/internal/rps/executor_test.go
+++ b/internal/rps/executor_test.go
@@ -1,0 +1,41 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2024
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package rps
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/device-management-toolkit/rpc-go/v2/internal/lm"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/heci"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClassifyLMSError pins the relay's error triage. The regression this guards
+// against: a read timeout with no bytes (lm.ErrLMSReadTimeoutNoData) is a benign
+// quiet round — AMT acknowledging a WSMAN request such as the activating Setup
+// without an immediate reply — and must NOT fail the activation on the plain
+// (non-TLS-tunnel) RPS relay. Genuine LMS errors must still classify as fatal.
+func TestClassifyLMSError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want lmsErrorClass
+	}{
+		{"heci poll timeout", heci.ErrReadTimeout, lmsErrorPoll},
+		{"wrapped heci poll timeout", fmt.Errorf("polling: %w", heci.ErrReadTimeout), lmsErrorPoll},
+		{"quiet round no data", lm.ErrLMSReadTimeoutNoData, lmsErrorQuietRound},
+		{"wrapped quiet round no data", fmt.Errorf("listen: %w", lm.ErrLMSReadTimeoutNoData), lmsErrorQuietRound},
+		{"genuine lms error is fatal", errors.New("connection reset by peer"), lmsErrorFatal},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyLMSError(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
**Fixed bugs: #1458, #1461.** `2915f0a` + `53147d3` + `9125bc0` + `e66dd7f` completes #1458 (started in [PR1462](https://github.com/device-management-toolkit/rpc-go/pull/1462)); `e3482f6` + `9125bc0` is part 1 of #1461 (completed by [PR1466](https://github.com/device-management-toolkit/rpc-go/pull/1466)).

> **Depends on** [PR1462](https://github.com/device-management-toolkit/rpc-go/pull/1462) (`fix/honor-firmware-status`) — review/merge that first.

5 commits. Fixes the false-**failure** cases: the device was provisioned (or
wedged) but rpc reported the opposite. Root cause: on TLS-enforced AMT (19/20/21)
`CommitChanges` restarts the AMT/LMS local port stack, and an ACM half-state
exposes a mutual-TLS port with no client cert.

### `fix(internal): treat post-commit connection drop as activation success` (`2915f0a`)
`CommitChanges` finalizes activation and restarts the port stack, tearing down
the LMS relay on :16993 **while the HTTP response is still in flight** →
`Post …/wsman: EOF`. Activation wrongly reported `ActivationFailed` and rolled
the already-provisioned ACM device back, so every ACM local activation over LMS
"failed" and needed a manual deactivate before retry.
- Both `CommitChanges` call sites now route through `commitActivation`, which —
  **only** on a connection-drop error (EOF / short read / reset / closed / APF
  channel-open failure, matched by type not substring) — re-reads the device
  state over HECI. Provisioned → treat commit as the success it was; still
  pre-provisioning → genuine failure.
- Application-level errors (e.g. 2057) are returned verbatim so the MEBx retry
  path is unaffected.
- `9125bc0` (below) tightened the success test: a control mode alone is no longer
  accepted as proof, and `e66dd7f` (below) added the error sentinel the LME
  transport actually emits.

```mermaid
flowchart TD
    A[CommitChanges over LMS/LME] --> B{error?}
    B -->|nil| S[activation success]
    B -->|app error e.g. 2057| E[return verbatim - MEBx retry path]
    B -->|other error| F[genuine failure]
    B -->|conn drop: EOF / unexpected EOF /<br/>reset / closed / APF open failure<br/>typed, not substring| C[re-read control mode over HECI]
    C --> D{mode != pre-provisioning?}
    D -->|no| R{retries left?}
    D -->|yes| G[read provisioning state over HECI]
    G -->|post-provisioning 2| S
    G -->|state unreadable| S
    G -->|in provisioning 1| R
    R -->|yes, after short delay| C
    R -->|budget exhausted| F
    S:::ok
    E:::warn
    F:::bad
    classDef ok fill:#1f7a1f,color:#fff
    classDef bad fill:#a11,color:#fff
    classDef warn fill:#a60,color:#fff
```

### `fix(lms): capture the slow, quiet AMT Setup response on the plain relay` (`53147d3`)
On the plain (non-tunnel) RPS relay the device activated yet rpc reported FAILED
(observed on AMT16/AMT18 remote ACM), for two reasons:
- A zero-byte LMS read (`lm.ErrLMSReadTimeoutNoData`) was treated as fatal. It's a
  normal quiet round. `classifyLMSError` now classifies the errors-channel value
  up front and treats this as benign on **both** tunnel and plain paths; genuine
  read errors arrive as other types and stay fatal.
- The pending response was still discarded: `lm.Listen` used a 500ms first-byte
  timeout, but the activating Setup runs provisioning crypto and its first byte
  lands ~1s out, so the reply was abandoned and RPS retried an already-activated
  device. Plain-relay first-byte timeout raised to **3s** (near-1s AMT ceiling
  with ~3× margin, under the executor's 4s `AMTResponseTimeout`). The TLS-tunnel
  path keeps its deliberately-short **2s** window so silent TLS 1.3 handshake
  rounds still yield promptly.

### `fix(internal): recover in-provisioning ACM deactivate over HECI` (`e3482f6`)
A device that halts mid-activation sits in admin control mode, provisioning state
"in provisioning". That half-state exposes a mutual-TLS :16993 and rpc has no
client cert, so every WSMAN deactivate fails at the handshake with
`tls: certificate required` (Error 109) — permanently wedged.
- On WSMAN `Unprovision` failure, read provisioning state over HECI (unaffected by
  the TLS-port state); if stuck "in provisioning", fall back to a HECI Unprovision
  that bypasses WSMAN/TLS. Triggers **only** for the confirmed half-state
  (classified by the typed provisioning-state value, not TLS error text); any
  other failure keeps its original error.

```mermaid
flowchart TD
    A[WSMAN Unprovision on :16993] --> B{result?}
    B -->|success| OK[device deactivated]
    B -->|tls: certificate required Error 109<br/>or other WSMAN failure| C[read provisioning state over HECI]
    C --> D{state == in provisioning?}
    D -->|yes half-state| E[HECI Unprovision<br/>bypasses WSMAN/TLS]
    D -->|no fully provisioned| F[keep original failure]
    E --> G{firmware status<br/>AND state?}
    G -->|both say deactivated| OK
    G -->|rejected| H[fall through to StopConfiguration<br/>PR4 · 92180bc]
    OK:::ok
    F:::bad
    classDef ok fill:#1f7a1f,color:#fff
    classDef bad fill:#a11,color:#fff
```

### `fix(internal): confirm post-provisioning before accepting a dropped commit` (`9125bc0`)
Review follow-up, two places where a partial signal was taken as proof of success.
- `commitActivation` accepted **any** control mode other than pre-provisioning as
  evidence the commit landed. A device that halts mid-activation reports ACM/CCM
  while still sitting in provisioning state 1, so a wedged activation was reported
  as a success. Post-provisioning is now required as well, and the existing retry
  loop gives the firmware time to advance out of in-provisioning. Escape hatch:
  firmware that cannot report a state at all falls back to the control-mode
  decision, so genuine activations on such platforms do not start failing.
- `recoverInProvisioningOverHECI` gated on `err == nil` alone, ignoring the state
  in the firmware response that `deactivateCCM` already checks — a rejected
  unprovision was reported as a successful deactivation. Both are now checked.
  This is the same rule PR1 establishes, applied to the fallback path.

### `fix(internal): treat a short read as a dropped post-commit connection` (`e66dd7f`)
`isConnectionResetErr` matched `io.EOF`, but the LME transport does not produce a
bare `io.EOF`: a response cut off mid-TLS-record surfaces as
`io.ErrUnexpectedEOF`, a **distinct sentinel** that `errors.Is` does not match
against `io.EOF`. Across every captured AMT20/AMT21 LME run the short read is what
appears and a clean `io.EOF` never does.

The gap stayed hidden because the two failure modes overlap. After the response is
lost the transport resets HECI and retries; while the firmware is still restarting
it refuses the new APF channel, `apf.ErrChannelOpenFailure` surfaces, *that* is
matched, and recovery works. Only when the retry does reopen the channel and
re-handshake, yet the response is still lost, does the short read reach
`commitActivation` on its own — roughly 1 in 6 LME ACM cycles on the affected
host.

Observed on AMT 20.0.5 (ISM):

```
Post "https://127.0.0.1:16993/wsman": read response over AMT TLS: unexpected EOF
```

followed by a rollback that failed with `AMT_STATUS_INVALID_AMT_MODE` — the device
was already provisioned and had nothing left to stop, confirming the commit had
landed and was misreported as a failure.

The test table asserted `io.EOF` and `apf.ErrChannelOpenFailure`, the errors the
code *assumed*, so it stayed green. It now covers the error the hardware emits.
`internal/local/amt` already pairs the two sentinels in `isTransientLMEError` and
`lmsUpButUnready`; this brings `commitActivation` in line.

## Acceptance
Post-commit connection drops — including the short read the LME transport actually
emits — are reconciled over HECI and treated as success **only** once the device
reports post-provisioning; the slow quiet Setup response is captured on the plain
relay; wedged in-provisioning ACM devices deactivate over the HECI fallback, with
the firmware's status deciding the outcome. Real failures remain failures: a
device still in provisioning state 1, or still pre-provisioning, is reported as a
failure.

```
 internal/commands/activate/commit_test.go | 231 ++++++++++++++++++++++++++++++
 internal/commands/activate/local.go       | 120 ++++++++++++++++++--
 internal/commands/activate/local_test.go  |   6 +-
 internal/commands/deactivate.go           |  68 +++++++++++--
 internal/commands/deactivate_test.go      | 117 +++++++++++++++++++++
 internal/lm/service.go                    |  70 +++++++++++----
 internal/lm/service_test.go               |  47 ++++++++
 internal/rps/executor.go                  |  58 ++++++++---
 internal/rps/executor_test.go             |  41 +++++++
 9 files changed, 714 insertions(+), 44 deletions(-)
```
