### PR TITLE
fix(internal): profile orchestration robustness (subprocess model)

### DIFF
--- a/internal/commands/activate/activate.go
+++ b/internal/commands/activate/activate.go
@@ -212,14 +212,19 @@ func (cmd *ActivateCmd) Run(ctx *commands.Context) error {
 	isProfileFile := cmd.Profile != "" && looksLikeFilePath(cmd.Profile)
 
 	if (cmd.Local || cmd.hasLocalActivationFlags()) && cmd.RequiresAMTPassword() {
+		// Profile flows (file or HTTP) orchestrate every AMT operation in
+		// subprocesses, so the parent must not open an LME/MEI handle here — a
+		// handle held across ExecuteProfile blocks each subprocess with EBUSY
+		// ("mei connect busy" → "device or resource busy"). Only the direct
+		// --ccm/--acm path (runLocalActivation) needs the parent WSMAN client.
 		if !isProfileFile {
 			if err := cmd.EnsureAMTPassword(ctx, cmd); err != nil {
 				return err
 			}
-		}
 
-		if err := cmd.EnsureWSMAN(ctx); err != nil {
-			return err
+			if err := cmd.EnsureWSMAN(ctx); err != nil {
+				return err
+			}
 		}
 	}
 	// Determine activation mode based on flags
@@ -363,6 +368,13 @@ func (cmd *ActivateCmd) runHttpProfileFullflow(ctx *commands.Context) error {
 	// Also store in ctx so postActivationSync can use it for WSMAN TLS probing.
 	if strings.TrimSpace(ctx.AMTPassword) == "" && amtPassword != "" {
 		ctx.AMTPassword = amtPassword
+	}
+
+	// Release any parent-held LME/MEI handle before orchestration; the subprocess
+	// steps each open their own handle and would otherwise fail with EBUSY.
+	if cmd.WSMan != nil {
+		cmd.WSMan.Close()
+		cmd.WSMan = nil
 	}
 
 	orch := orchestrator.NewProfileOrchestrator(cfg, ctx.AMTPassword, cmd.MEBxPassword, ctx.SkipAMTCertCheck)
@@ -638,6 +650,13 @@ func (cmd *ActivateCmd) runLocalProfileFullflow(ctx *commands.Context) error {
 	// Store resolved AMT password in ctx so postActivationSync WSMAN TLS probe works.
 	if strings.TrimSpace(ctx.AMTPassword) == "" && amtPassword != "" {
 		ctx.AMTPassword = amtPassword
+	}
+
+	// Release any parent-held LME/MEI handle before orchestration; the subprocess
+	// steps each open their own handle and would otherwise fail with EBUSY.
+	if cmd.WSMan != nil {
+		cmd.WSMan.Close()
+		cmd.WSMan = nil
 	}
 
 	orch := orchestrator.NewProfileOrchestrator(cfg, ctx.AMTPassword, cmd.MEBxPassword, ctx.SkipAMTCertCheck)

--- a/internal/commands/activate/activate.go
+++ b/internal/commands/activate/activate.go
@@ -212,11 +212,17 @@ func (cmd *ActivateCmd) Run(ctx *commands.Context) error {
 	isProfileFile := cmd.Profile != "" && looksLikeFilePath(cmd.Profile)
 
 	if (cmd.Local || cmd.hasLocalActivationFlags()) && cmd.RequiresAMTPassword() {
-		// Profile flows (file or HTTP) orchestrate every AMT operation in
-		// subprocesses, so the parent must not open an LME/MEI handle here — a
-		// handle held across ExecuteProfile blocks each subprocess with EBUSY
-		// ("mei connect busy" → "device or resource busy"). Only the direct
-		// --ccm/--acm path (runLocalActivation) needs the parent WSMAN client.
+		// Profile flows orchestrate every AMT operation in subprocesses, so the
+		// parent must not open an LME/MEI handle here — a handle held across
+		// ExecuteProfile blocks each subprocess with EBUSY ("mei connect busy" →
+		// "device or resource busy"). Only the direct --ccm/--acm path
+		// (runLocalActivation) needs the parent WSMAN client.
+		//
+		// This guard covers the profile-*file* path only. The HTTP profile path
+		// never reaches it (it requires cmd.Local || hasLocalActivationFlags()),
+		// and it deliberately opens WSMAN of its own below to read live TLS state
+		// off an already-activated device, releasing the handle again before
+		// orchestration starts.
 		if !isProfileFile {
 			if err := cmd.EnsureAMTPassword(ctx, cmd); err != nil {
 				return err
@@ -371,7 +377,11 @@ func (cmd *ActivateCmd) runHttpProfileFullflow(ctx *commands.Context) error {
 	}
 
 	// Release any parent-held LME/MEI handle before orchestration; the subprocess
-	// steps each open their own handle and would otherwise fail with EBUSY.
+	// steps each open their own handle and would otherwise fail with EBUSY
+	// ("mei connect busy" → "device or resource busy"). Whether the parent handle
+	// actually blocks a subprocess depends on the OS and the LMS build, so this
+	// close reproduces as a failure only on some combinations — do not remove it
+	// as dead code because a given machine survives without it.
 	if cmd.WSMan != nil {
 		cmd.WSMan.Close()
 		cmd.WSMan = nil
@@ -653,7 +663,11 @@ func (cmd *ActivateCmd) runLocalProfileFullflow(ctx *commands.Context) error {
 	}
 
 	// Release any parent-held LME/MEI handle before orchestration; the subprocess
-	// steps each open their own handle and would otherwise fail with EBUSY.
+	// steps each open their own handle and would otherwise fail with EBUSY
+	// ("mei connect busy" → "device or resource busy"). Whether the parent handle
+	// actually blocks a subprocess depends on the OS and the LMS build, so this
+	// close reproduces as a failure only on some combinations — do not remove it
+	// as dead code because a given machine survives without it.
 	if cmd.WSMan != nil {
 		cmd.WSMan.Close()
 		cmd.WSMan = nil

--- a/internal/commands/activate/activate_test.go
+++ b/internal/commands/activate/activate_test.go
@@ -987,6 +987,36 @@ func TestActivateCmd_Run_ProfileFileSkipsPasswordPrompt(t *testing.T) {
 	assert.False(t, spy.Called, "password prompt should not be triggered when profile file is provided")
 }
 
+func TestActivateCmd_Run_ProfileFileDoesNotOpenParentWSMAN(t *testing.T) {
+	// Regression: the profile fullflow orchestrates AMT operations in subprocesses,
+	// each of which opens its own LME/MEI handle. If the parent opens a WSMAN/LME
+	// handle here (via EnsureWSMAN) it holds /dev/mei0 across ExecuteProfile and every
+	// subprocess fails with EBUSY ("mei connect busy" → "device or resource busy").
+	// A password being available in ctx must NOT cause the parent to open a handle
+	// when the target is a profile file.
+	spy := &MockPasswordReaderSpy{}
+	origPR := utils.PR
+	utils.PR = spy
+
+	defer func() { utils.PR = origPR }()
+
+	cmd := &ActivateCmd{
+		Profile:          "config.yaml", // file path triggers profile fullflow
+		Key:              "some-encryption-key",
+		ProvisioningCert: "base64cert", // triggers hasLocalActivationFlags()
+	}
+	cmd.ControlMode = 0
+
+	// Password present in ctx would satisfy EnsureWSMAN's precondition if it were called.
+	ctx := &commands.Context{AMTPassword: utils.TestPassword}
+
+	// Run fails when decrypting the non-existent profile file; the assertion is that
+	// no parent-side WSMAN handle was ever created.
+	_ = cmd.Run(ctx)
+
+	assert.Nil(t, cmd.WSMan, "parent must not open a WSMAN/LME handle for the profile-file path")
+}
+
 func TestPostActivationSync_SendsPatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/commands/configure/constants.go
+++ b/internal/commands/configure/constants.go
@@ -4,10 +4,13 @@
  **********************************************************************/
 package configure
 
-import "errors"
+import "github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 
 // Error messages
 var (
-	// ErrDeviceNotActivated indicates the device is not activated and cannot be configured
-	ErrDeviceNotActivated = errors.New("device is not activated to configure. Please activate the device first")
+	// ErrDeviceNotActivated indicates the device is not activated and cannot be
+	// configured. It is a utils.CustomError so that subprocess invocations exit
+	// with a distinct code (DeviceNotActivated) the orchestrator can match on,
+	// rather than the generic failure code — see orchestrator.isDeviceNotActivatedErr.
+	ErrDeviceNotActivated = utils.DeviceNotActivated
 )

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -251,7 +251,13 @@ func (po *ProfileOrchestrator) executeWithPasswordFallback(args []string) error 
 			attempt, postActivationSettleAttempts, err, po.settleDelaySeconds)
 		utils.Pause(po.settleDelaySeconds)
 
-		err = po.executeWithPasswordRotation(args)
+		// Retry the step directly rather than through executeWithPasswordRotation.
+		// Rotation already ran on the initial execution above; re-entering it here
+		// would prompt for the current password again on every settle attempt
+		// (worst case attempts × maxTries prompts) and, on success, recurse back
+		// into this loop. Settle retries exist to wait out a restarting port stack,
+		// which needs no credential interaction.
+		err = po.executor.Execute(args)
 		if err == nil {
 			return nil
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -31,6 +31,20 @@ const (
 	// msgPasswordAlignSkipped is logged when AMT password alignment is skipped
 	// because the device is not yet activated; activation continues afterward.
 	msgPasswordAlignSkipped = "AMT password alignment skipped: device is not activated yet; will continue with activation"
+
+	// postActivationSettleAttempts bounds how many extra times a configuration
+	// step is retried when it fails while the AMT firmware is still settling
+	// after activation. Right after activation the firmware restarts its local
+	// management (LMS) port stack and can briefly lock the admin account, so a
+	// step fired into that window fails with a dropped connection (EOF/reset) or
+	// a transient "account temporarily locked" 401 even though the password is
+	// correct. A fresh subprocess retried after a delay re-authenticates against
+	// the now-settled firmware and succeeds.
+	postActivationSettleAttempts = 4
+	// postActivationSettleDelaySeconds is the wait between post-activation settle
+	// retries, giving the firmware time to finish the port-stack restart and
+	// clear the transient account lock.
+	postActivationSettleDelaySeconds = 3
 )
 
 // ProfileOrchestrator orchestrates the execution of commands from a profile configuration
@@ -47,6 +61,15 @@ type ProfileOrchestrator struct {
 	globalPassword string
 	// skip AMT certificate verification when connecting over TLS
 	skipAMTCertCheck bool
+	// activatedThisRun is set once this orchestration performs activation. It
+	// gates the post-activation settle retries so they only apply while the
+	// firmware is restarting its port stack; on an already-activated device a
+	// configuration failure is genuine and must fail fast.
+	activatedThisRun bool
+	// settleDelaySeconds is the wait between post-activation settle retries.
+	// Defaults to postActivationSettleDelaySeconds; overridable in tests to
+	// avoid real sleeps.
+	settleDelaySeconds int
 }
 
 // NewProfileOrchestrator creates a new profile orchestrator. The currentPassword argument
@@ -56,12 +79,13 @@ type ProfileOrchestrator struct {
 // argument controls whether AMT TLS certificate verification should be skipped for sub-commands.
 func NewProfileOrchestrator(cfg config.Configuration, currentPassword, mebxPassword string, skipAMTCertCheck bool) *ProfileOrchestrator {
 	return &ProfileOrchestrator{
-		profile:          cfg,
-		executor:         &CLIExecutor{},
-		currentPassword:  strings.TrimSpace(currentPassword),
-		mebxPassword:     strings.TrimSpace(mebxPassword),
-		globalPassword:   strings.TrimSpace(cfg.Configuration.AMTSpecific.AdminPassword),
-		skipAMTCertCheck: skipAMTCertCheck,
+		profile:            cfg,
+		executor:           &CLIExecutor{},
+		currentPassword:    strings.TrimSpace(currentPassword),
+		mebxPassword:       strings.TrimSpace(mebxPassword),
+		globalPassword:     strings.TrimSpace(cfg.Configuration.AMTSpecific.AdminPassword),
+		skipAMTCertCheck:   skipAMTCertCheck,
+		settleDelaySeconds: postActivationSettleDelaySeconds,
 	}
 }
 
@@ -126,16 +150,28 @@ func (po *ProfileOrchestrator) ExecuteProfile() error {
 		if err := po.executeActivation(); err != nil {
 			return fmt.Errorf("activation failed: %w", err)
 		}
+
+		po.activatedThisRun = true
 	} else if currentControlMode == 0 {
 		if err := po.executeActivation(); err != nil {
 			return fmt.Errorf("activation failed: %w", err)
 		}
+
+		po.activatedThisRun = true
 	} else {
 		log.Info("AMT already activated, skipping activation step")
 	}
 
-	// wait a sec after activation
-	utils.Pause(1)
+	// Give the firmware time to settle before the first configuration step. When
+	// we just activated, the firmware is restarting its local management (LMS)
+	// port stack and briefly locks the admin account, so a longer initial wait
+	// lets the first step authenticate on a settled stack rather than burning a
+	// settle retry (and adding to the lockout counter) on a doomed attempt.
+	if po.activatedThisRun {
+		utils.Pause(postActivationSettleDelaySeconds)
+	} else {
+		utils.Pause(1)
+	}
 
 	// Step 2: MEBx password configuration (ACM only)
 	if err := po.executeMEBxConfiguration(); err != nil {
@@ -182,9 +218,51 @@ func (po *ProfileOrchestrator) ExecuteProfile() error {
 	return nil
 }
 
-// executeWithPasswordFallback executes a CLI command and, on authentication failure,
-// prompts for the old AMT password to rotate it to the profile's new password, then retries.
+// executeWithPasswordFallback runs a configuration step, absorbing the transient
+// failures that occur while the AMT firmware is still settling after activation.
+//
+// Right after activation the firmware restarts its local management (LMS) port
+// stack and can briefly lock the admin account. A step fired into that window
+// fails with a dropped connection (EOF/reset) or a transient "account
+// temporarily locked" 401 even though the password is correct — the same
+// port-stack-restart race already handled on the activation commit and the LMS
+// dial. Because each step is a fresh subprocess that re-authenticates (new
+// digest challenge) and re-reads control mode, simply retrying after a short
+// delay lets it succeed once the firmware settles. Retries apply only when this
+// run performed activation; on an already-activated device a failure is genuine
+// and returned immediately. The underlying state-set operations are idempotent,
+// so re-applying a step that partially succeeded is safe.
 func (po *ProfileOrchestrator) executeWithPasswordFallback(args []string) error {
+	err := po.executeWithPasswordRotation(args)
+	if err == nil || !po.activatedThisRun {
+		return err
+	}
+
+	// The initial execution above is attempt 1; the loop covers retries 2..N so
+	// the logged "attempt X/N" matches the real execution count.
+	for attempt := 2; attempt <= postActivationSettleAttempts; attempt++ {
+		// A device-not-activated failure is not a settling symptom; retrying
+		// won't help, so surface it right away.
+		if isDeviceNotActivatedErr(err) {
+			return err
+		}
+
+		log.Warnf("Configuration step failed while AMT may still be settling after activation (attempt %d/%d): %v. Retrying in %ds...",
+			attempt, postActivationSettleAttempts, err, po.settleDelaySeconds)
+		utils.Pause(po.settleDelaySeconds)
+
+		err = po.executeWithPasswordRotation(args)
+		if err == nil {
+			return nil
+		}
+	}
+
+	return err
+}
+
+// executeWithPasswordRotation executes a CLI command and, on authentication failure,
+// prompts for the old AMT password to rotate it to the profile's new password, then retries.
+func (po *ProfileOrchestrator) executeWithPasswordRotation(args []string) error {
 	err := po.executor.Execute(args)
 	if err == nil {
 		return nil

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -27,6 +27,10 @@ const (
 	commandAMTPassword = "amtpassword"
 	flagPassword       = "--password"
 	flagNewAMTPassword = "--newamtpassword"
+
+	// msgPasswordAlignSkipped is logged when AMT password alignment is skipped
+	// because the device is not yet activated; activation continues afterward.
+	msgPasswordAlignSkipped = "AMT password alignment skipped: device is not activated yet; will continue with activation"
 )
 
 // ProfileOrchestrator orchestrates the execution of commands from a profile configuration
@@ -704,6 +708,10 @@ func (po *ProfileOrchestrator) verifyAndAlignAMTPassword() error {
 			log.Info("AMT password aligned to profile value using provided current password")
 
 			return nil
+		} else if isDeviceNotActivatedErr(err) {
+			log.Warn(msgPasswordAlignSkipped)
+
+			return nil
 		}
 		// If it failed (e.g., wrong provided current), proceed to auth-probe and interactive fallback
 	}
@@ -715,5 +723,30 @@ func (po *ProfileOrchestrator) verifyAndAlignAMTPassword() error {
 	args := po.baseArgs()
 	args = append(args, commandConfigure, commandAMTPassword, flagNewAMTPassword, newPass)
 
-	return po.executeWithPasswordFallback(args)
+	err := po.executeWithPasswordFallback(args)
+	if isDeviceNotActivatedErr(err) {
+		log.Warn(msgPasswordAlignSkipped)
+
+		return nil
+	}
+
+	return err
+}
+
+// isDeviceNotActivatedErr reports whether err signals that a configure subprocess
+// refused because the device is not yet activated. The orchestrator drives every
+// step through CLIExecutor, which reports failures as *ExecError, so we match on
+// the typed exit code rather than substring-matching subprocess output (verbose
+// Digest logs make substring matching unreliable — see CLAUDE.md).
+func isDeviceNotActivatedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var execErr *ExecError
+	if errors.As(err, &execErr) {
+		return execErr.ExitCode == utils.DeviceNotActivated.Code
+	}
+
+	return false
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -317,6 +317,91 @@ func TestExecuteWithPasswordFallback_AuthExitCodeTriggersRotationAndRetry(t *tes
 	}
 }
 
+func TestExecuteWithPasswordFallback_NoSettleRetryWhenNotActivatedThisRun(t *testing.T) {
+	cfg := config.Configuration{}
+
+	po := NewProfileOrchestrator(cfg, "", "", false)
+	mock := newMockExecutor()
+	mock.errs = []error{nonAuthExecError()}
+	po.executor = mock
+	po.settleDelaySeconds = 0
+	// activatedThisRun defaults to false: device was already activated, so a
+	// configuration failure is genuine and must fail fast without settle retries.
+
+	err := po.executeWithPasswordFallback([]string{"rpc", "configure", "wifisync"})
+	if err == nil {
+		t.Fatalf("expected error to surface, got nil")
+	}
+
+	if mock.callCount != 1 {
+		t.Errorf("expected 1 call (no settle retry when not activated this run), got %d", mock.callCount)
+	}
+}
+
+func TestExecuteWithPasswordFallback_SettleRetryRecoversAfterActivation(t *testing.T) {
+	cfg := config.Configuration{}
+
+	po := NewProfileOrchestrator(cfg, "", "", false)
+	mock := newMockExecutor()
+	// Two transient post-activation failures (dropped connection / locked
+	// account), then success once the firmware settles.
+	mock.errs = []error{nonAuthExecError(), nonAuthExecError(), nil}
+	po.executor = mock
+	po.settleDelaySeconds = 0
+	po.activatedThisRun = true
+
+	err := po.executeWithPasswordFallback([]string{"rpc", "configure", "wifisync"})
+	if err != nil {
+		t.Fatalf("executeWithPasswordFallback() error = %v, want nil after settle retry", err)
+	}
+
+	if mock.callCount != 3 {
+		t.Fatalf("expected 3 calls (fail, fail, succeed), got %d", mock.callCount)
+	}
+}
+
+func TestExecuteWithPasswordFallback_SettleRetryBounded(t *testing.T) {
+	cfg := config.Configuration{}
+
+	po := NewProfileOrchestrator(cfg, "", "", false)
+	mock := newMockExecutor()
+	// Every attempt fails; the retry loop must be bounded and then surface the error.
+	mock.errs = []error{nonAuthExecError(), nonAuthExecError(), nonAuthExecError(), nonAuthExecError(), nonAuthExecError()}
+	po.executor = mock
+	po.settleDelaySeconds = 0
+	po.activatedThisRun = true
+
+	err := po.executeWithPasswordFallback([]string{"rpc", "configure", "wifisync"})
+	if err == nil {
+		t.Fatalf("expected error to surface after exhausting settle retries, got nil")
+	}
+
+	if mock.callCount != postActivationSettleAttempts {
+		t.Errorf("expected %d calls (bounded settle retries), got %d", postActivationSettleAttempts, mock.callCount)
+	}
+}
+
+func TestExecuteWithPasswordFallback_SettleRetrySkippedForDeviceNotActivated(t *testing.T) {
+	cfg := config.Configuration{}
+
+	po := NewProfileOrchestrator(cfg, "", "", false)
+	mock := newMockExecutor()
+	// A device-not-activated failure is not a settling symptom; do not retry.
+	mock.errs = []error{deviceNotActivatedExecError()}
+	po.executor = mock
+	po.settleDelaySeconds = 0
+	po.activatedThisRun = true
+
+	err := po.executeWithPasswordFallback([]string{"rpc", "configure", "wifisync"})
+	if err == nil {
+		t.Fatalf("expected device-not-activated error to surface, got nil")
+	}
+
+	if mock.callCount != 1 {
+		t.Errorf("expected 1 call (no settle retry for device-not-activated), got %d", mock.callCount)
+	}
+}
+
 func TestExecuteMEBxConfiguration_RunsWhenAlreadyActivated(t *testing.T) {
 	cfg := config.Configuration{}
 	cfg.Configuration.AMTSpecific.MEBXPassword = "mebx-pwd"

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6,7 +6,9 @@
 package orchestrator
 
 import (
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -399,6 +401,68 @@ func TestExecuteWithPasswordFallback_SettleRetrySkippedForDeviceNotActivated(t *
 
 	if mock.callCount != 1 {
 		t.Errorf("expected 1 call (no settle retry for device-not-activated), got %d", mock.callCount)
+	}
+}
+
+// failingPasswordReader stands in for an interactive prompt. Any read is a test
+// failure signal: settle retries must never reach the password prompt.
+type failingPasswordReader struct{}
+
+func (r *failingPasswordReader) ReadPassword() (string, error) {
+	return "", errors.New("password prompt must not be reached during settle retries")
+}
+
+func (r *failingPasswordReader) ReadPasswordWithConfirmation(prompt, confirmPrompt string) (string, error) {
+	return "", errors.New("password prompt must not be reached during settle retries")
+}
+
+// TestExecuteWithPasswordFallback_SettleRetryDoesNotRePrompt pins the retry path:
+// rotation runs once, on the initial execution. Routing settle retries back
+// through executeWithPasswordRotation would re-prompt on every attempt and, on
+// success, recurse into the settle loop again.
+func TestExecuteWithPasswordFallback_SettleRetryDoesNotRePrompt(t *testing.T) {
+	originalPR := utils.PR
+	utils.PR = &failingPasswordReader{}
+
+	defer func() { utils.PR = originalPR }()
+
+	cfg := config.Configuration{}
+	// An AdminPassword plus control mode 2 is what arms the rotation path.
+	cfg.Configuration.AMTSpecific.AdminPassword = "new-pass"
+
+	// A supplied current password arms the non-interactive rotation attempt.
+	po := NewProfileOrchestrator(cfg, "old-pass", "", false)
+	mock := newMockExecutor()
+	// Every call reports an auth failure — the error that triggers rotation. The
+	// slice is longer than any path through the loop needs, so a rotating retry
+	// path cannot pass by simply running out of errors.
+	mock.errs = make([]error, 32)
+	for i := range mock.errs {
+		mock.errs[i] = authExecError()
+	}
+
+	po.executor = mock
+	po.settleDelaySeconds = 0
+	po.activatedThisRun = true
+	po.currentControlMode = 2
+
+	if err := po.executeWithPasswordFallback([]string{"rpc", "configure", "wifisync"}); err == nil {
+		t.Fatalf("expected error to surface after exhausting settle retries, got nil")
+	}
+
+	rotations := 0
+
+	for _, args := range mock.executedArgs {
+		if slices.Contains(args, commandAMTPassword) {
+			rotations++
+		}
+	}
+
+	// Exactly one: the initial execution's rotation. Routing the retries back
+	// through executeWithPasswordRotation would rotate once per settle attempt.
+	if rotations != 1 {
+		t.Errorf("expected 1 rotation attempt (the initial one), got %d across %s",
+			rotations, strings.Join(mock.executedArgs[len(mock.executedArgs)-1], " "))
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -342,3 +342,53 @@ func TestExecuteMEBxConfiguration_RunsWhenAlreadyActivated(t *testing.T) {
 		t.Errorf("expected MEBx configure command, got: %s", argsStr)
 	}
 }
+
+func deviceNotActivatedExecError() error {
+	return &ExecError{
+		ExitCode: utils.DeviceNotActivated.Code,
+		Output:   "device is not activated to configure. Please activate the device first",
+		Err:      fmt.Errorf("exit status %d", utils.DeviceNotActivated.Code),
+	}
+}
+
+func TestVerifyAndAlignAMTPassword_SkipsWhenDeviceNotActivated_WithCurrentPassword(t *testing.T) {
+	cfg := config.Configuration{}
+	cfg.Configuration.AMTSpecific.AdminPassword = "new-pass"
+
+	po := NewProfileOrchestrator(cfg, "old-pass", "", false)
+	po.currentControlMode = 2
+
+	mock := newMockExecutor()
+	mock.errs = []error{deviceNotActivatedExecError()}
+	po.executor = mock
+
+	err := po.verifyAndAlignAMTPassword()
+	if err != nil {
+		t.Fatalf("verifyAndAlignAMTPassword() error = %v, want nil", err)
+	}
+
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 call and graceful skip, got %d", mock.callCount)
+	}
+}
+
+func TestVerifyAndAlignAMTPassword_SkipsWhenDeviceNotActivated_NoCurrentPassword(t *testing.T) {
+	cfg := config.Configuration{}
+	cfg.Configuration.AMTSpecific.AdminPassword = "new-pass"
+
+	po := NewProfileOrchestrator(cfg, "", "", false)
+	po.currentControlMode = 0 // executeWithPasswordFallback returns original error in pre-provisioning
+
+	mock := newMockExecutor()
+	mock.errs = []error{deviceNotActivatedExecError()}
+	po.executor = mock
+
+	err := po.verifyAndAlignAMTPassword()
+	if err != nil {
+		t.Fatalf("verifyAndAlignAMTPassword() error = %v, want nil", err)
+	}
+
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 call and graceful skip, got %d", mock.callCount)
+	}
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -154,6 +154,7 @@ var (
 	WifiConfigurationWithWarnings     = CustomError{Code: 112, Message: "WifiConfigurationWithWarnings"}
 	UnmarshalMessageFailed            = CustomError{Code: 113, Message: "UnmarshalMessageFailed"}
 	DeleteConfigsFailed               = CustomError{Code: 114, Message: "DeleteConfigsFailed"}
+	DeviceNotActivated                = CustomError{Code: 115, Message: "DeviceNotActivated", Details: "device is not activated to configure. Please activate the device first"}
 	MissingOrIncorrectWifiProfileName = CustomError{Code: 116, Message: "MissingOrIncorrectWifiProfileName"}
 	MissingIeee8021xConfiguration     = CustomError{Code: 117, Message: "MissingIeee8021xConfiguration"}
 	SetMEBXPasswordFailed             = CustomError{Code: 118, Message: "SetMEBXPasswordFailed"}


### PR DESCRIPTION
**Fixed bugs: #1459, #1310.**

> **Depends on** [PR1463](https://github.com/device-management-toolkit/rpc-go/pull/1463) (`fix/local-outcome-correctness`) — review/merge that first.

4 commits. Profile flows orchestrate every AMT operation in subprocesses; three
issues break that model.

### `fix(internal): release parent MEI handle before profile orchestration` (`c309a7c`)
A parent-held LME/MEI handle across `ExecuteProfile` blocks each subprocess with
EBUSY (`mei connect busy` → `device or resource busy`). Profile-file activation
now skips the parent `EnsureWSMAN` and closes any held WSMan handle before
starting the orchestrator; only the direct `--ccm/--acm` path keeps the parent
client.

### `fix(internal): skip AMT password alignment on unactivated device` (`102b67d`)
`verifyAndAlignAMTPassword` ran a `configure amtpassword` step even on an
unactivated device, failing with "device is not activated to configure". The
configure subcommand now returns the new `utils.DeviceNotActivated` (code 115)
`CustomError`, and `isDeviceNotActivatedErr` matches on
`ExecError.ExitCode`/`CustomError.Code` — so alignment is skipped (and activation
continues) rather than aborting.

### `fix(internal): retry config steps while AMT settles post-activation` (`5d37697`)
Right after activation the firmware restarts the LMS port stack and briefly locks
the admin account, so config steps fired into that window fail with a dropped
connection or a transient "account temporarily locked" 401 despite a correct
password (observed: AMT16 WiFi-sync 401, AMT18 KVM `RequestStateChange` EOF;
proven transient — amtinfo succeeds seconds later with the same password).
- `executeWithPasswordFallback` now retries the underlying step (fresh subprocess,
  new digest challenge, re-read control mode) a bounded number of times after a
  short delay. Retries are **gated on `activatedThisRun`** (already-activated
  devices still fail fast), skip `DeviceNotActivated`, and rely on idempotent
  steps.
- The initial post-activation wait is lengthened when we just activated, so the
  first step lands on a settled stack instead of burning a retry (and
  incrementing the lockout counter) on a doomed attempt.

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant S as configure step (subprocess)
    participant FW as AMT firmware
    O->>FW: activate (--acm/--ccm)
    Note over FW: port stack restarts +<br/>admin account briefly locked
    O->>O: lengthened post-activation wait
    loop bounded settle-retry (activatedThisRun only)
        O->>S: fresh subprocess, new digest<br/>(executor direct, no rotation)
        S->>FW: WSMAN config call
        alt transient (EOF/reset or 401 locked)
            FW-->>S: dropped/locked
            S-->>O: retryable error
            O->>O: short delay, retry
        else success
            FW-->>S: ok
            S-->>O: done
        else DeviceNotActivated / non-transient
            S-->>O: fail fast (no retry)
        end
    end
```

### `fix(internal): stop settle retries from re-prompting for the AMT password` (`1064227`)
Review follow-up. Settle retries went back through
`executeWithPasswordRotation`. Rotation had already run on the initial execution,
so re-entering it could only prompt for the current password again — worst case
`attempts × maxTries` interactive prompts — and, on a successful rotation, recurse
back into the settle loop. Retries now call the executor directly: waiting out a
restarting port stack needs no credential interaction.

Also records two things reviewers asked about, with no behaviour change:

- The WSMAN-skip guard covers the **profile-file** path only. The HTTP-fullflow
  path deliberately opens WSMAN to read live TLS state off an already-activated
  device and releases it again before orchestration, and it never reaches the
  guard (which requires `cmd.Local || hasLocalActivationFlags()`), so gating the
  guard on HTTP profiles too would be wrong.
- The parent MEI handle release prevents an EBUSY that only reproduces on some
  OS/LMS combinations, so it must not be removed later as dead code.

Copilot's `attempt %d/%d` off-by-one on the settle loop was already fixed: the
loop starts at `attempt := 2` with an explanatory comment
(`internal/orchestrator/orchestrator.go:243`).

## Acceptance
Profile subprocesses no longer hit EBUSY; unactivated-device password alignment
is skipped and logged; post-activation config steps retry within a bounded
window **without re-prompting for a password**; non-transient failures still fail
fast.

```
 internal/commands/activate/activate.go      |  39 +++++++-
 internal/commands/activate/activate_test.go |  30 ++++++
 internal/commands/configure/constants.go    |   9 +-
 internal/orchestrator/orchestrator.go       | 139 +++++++++++++++++++++++---
 internal/orchestrator/orchestrator_test.go  | 199 +++++++++++++++++++++++++++++
 pkg/utils/constants.go                      |   1 +
 6 files changed, 400 insertions(+), 17 deletions(-)
```
