### PR TITLE
fix(local): local LMS/LME transport reliability and log noise

### DIFF
--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -433,18 +433,32 @@ func (cmd *DeactivateCmd) provisioningHalted(ctx *Context) bool {
 func (cmd *DeactivateCmd) recoverInProvisioningOverHECI(ctx *Context, wsmanErr error) error {
 	log.Warnf("WSMAN deactivate failed while device is in provisioning (%v); recovering over HECI", wsmanErr)
 
-	// Unprovision reports failure through the state in the firmware response as
-	// well as through err — deactivateCCM below checks both. Gating on err alone
-	// would report a firmware-rejected unprovision as a successful deactivation.
 	state, err := ctx.AMTCommand.Unprovision()
 
+	// Unprovision reports failure through the state in the firmware response as
+	// well as through err — deactivateCCM below checks both. Gating on err alone
+	// would report a firmware-rejected unprovision as a successful deactivation
+	// and skip the StopConfiguration fallback.
 	switch {
 	case err != nil:
-		log.Error("Status: Unable to deactivate over HECI ", err)
+		log.Warnf("HECI unprovision failed for in-provisioning device (%v); stopping incomplete configuration", err)
+	case state != 0:
+		log.Warnf("HECI unprovision for in-provisioning device reported state %d; stopping incomplete configuration", state)
+	default:
+		log.Info("Status: Device deactivated")
+
+		return nil
+	}
+
+	stopResp, stopErr := ctx.AMTCommand.StopConfiguration()
+	if stopErr != nil {
+		log.Error("Status: Unable to stop incomplete configuration over HECI ", stopErr)
 
 		return utils.UnableToDeactivate
-	case state != 0:
-		log.Errorf("Status: Unable to deactivate over HECI; firmware reported state %d", state)
+	}
+
+	if stopResp.Status != "AMT_STATUS_SUCCESS" {
+		log.Errorf("Status: Unable to stop incomplete configuration over HECI: %s", stopResp.Status)
 
 		return utils.UnableToDeactivate
 	}

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -32,6 +32,10 @@ const (
 // complete — it must be recovered over HECI instead.
 const provisioningStateInProvisioning = 1
 
+// amtStatusSuccess is the firmware status string a successful HECI command
+// reports in its response.
+const amtStatusSuccess = "AMT_STATUS_SUCCESS"
+
 // setupTLSConfig creates TLS configuration if local TLS is enforced
 func (cmd *DeactivateCmd) setupTLSConfig(ctx *Context) *tls.Config {
 	tlsConfig := &tls.Config{}
@@ -457,7 +461,7 @@ func (cmd *DeactivateCmd) recoverInProvisioningOverHECI(ctx *Context, wsmanErr e
 		return utils.UnableToDeactivate
 	}
 
-	if stopResp.Status != "AMT_STATUS_SUCCESS" {
+	if stopResp.Status != amtStatusSuccess {
 		log.Errorf("Status: Unable to stop incomplete configuration over HECI: %s", stopResp.Status)
 
 		return utils.UnableToDeactivate

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -433,8 +433,23 @@ func (cmd *DeactivateCmd) provisioningHalted(ctx *Context) bool {
 func (cmd *DeactivateCmd) recoverInProvisioningOverHECI(ctx *Context, wsmanErr error) error {
 	log.Warnf("WSMAN deactivate failed while device is in provisioning (%v); recovering over HECI", wsmanErr)
 
-	if _, err := ctx.AMTCommand.Unprovision(); err != nil {
-		log.Error("Status: Unable to deactivate over HECI ", err)
+	if _, err := ctx.AMTCommand.Unprovision(); err == nil {
+		log.Info("Status: Device deactivated")
+
+		return nil
+	} else {
+		log.Warnf("HECI unprovision failed for in-provisioning device (%v); stopping incomplete configuration", err)
+	}
+
+	stopResp, stopErr := ctx.AMTCommand.StopConfiguration()
+	if stopErr != nil {
+		log.Error("Status: Unable to stop incomplete configuration over HECI ", stopErr)
+
+		return utils.UnableToDeactivate
+	}
+
+	if stopResp.Status != "AMT_STATUS_SUCCESS" {
+		log.Errorf("Status: Unable to stop incomplete configuration over HECI: %s", stopResp.Status)
 
 		return utils.UnableToDeactivate
 	}

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
 	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -883,7 +884,7 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("HECI unprovision reporting a non-zero state is not a success", func(t *testing.T) {
+	t.Run("HECI unprovision reporting a non-zero state falls through to stop-config", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -892,14 +893,16 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 
 		mockAMT := mock.NewMockInterface(ctrl)
 		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
-		// Firmware rejected the request through the response state, not through err.
+		// Firmware rejected the request through the response state, not through
+		// err. That must not read as success — the stop-config fallback still runs.
 		mockAMT.EXPECT().Unprovision().Return(1, nil)
+		mockAMT.EXPECT().StopConfiguration().Return(amt.StopConfigurationResponse{Status: "AMT_STATUS_SUCCESS"}, nil)
 
 		cmd := &DeactivateCmd{}
 		cmd.WSMan = mockWSMAN
 
 		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
-		assert.ErrorIs(t, err, utils.UnableToDeactivate)
+		assert.NoError(t, err)
 	})
 
 	t.Run("provisioned device does not fall back to HECI", func(t *testing.T) {
@@ -920,7 +923,7 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 		assert.ErrorIs(t, err, utils.UnableToDeactivate)
 	})
 
-	t.Run("HECI recovery failure surfaces UnableToDeactivate", func(t *testing.T) {
+	t.Run("HECI unprovision rejection stops incomplete configuration", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -930,6 +933,26 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 		mockAMT := mock.NewMockInterface(ctrl)
 		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
 		mockAMT.EXPECT().Unprovision().Return(-1, errors.New("invalid AMT mode"))
+		mockAMT.EXPECT().StopConfiguration().Return(amt.StopConfigurationResponse{Status: "AMT_STATUS_SUCCESS"}, nil)
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.NoError(t, err)
+	})
+
+	t.Run("StopConfiguration rejection surfaces UnableToDeactivate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, tlsCertRequired)
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
+		mockAMT.EXPECT().Unprovision().Return(-1, errors.New("invalid AMT mode"))
+		mockAMT.EXPECT().StopConfiguration().Return(amt.StopConfigurationResponse{Status: "AMT_STATUS_INVALID_AMT_MODE"}, nil)
 
 		cmd := &DeactivateCmd{}
 		cmd.WSMan = mockWSMAN

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
 	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -901,7 +902,7 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 		assert.ErrorIs(t, err, utils.UnableToDeactivate)
 	})
 
-	t.Run("HECI recovery failure surfaces UnableToDeactivate", func(t *testing.T) {
+	t.Run("HECI unprovision rejection stops incomplete configuration", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -911,6 +912,26 @@ func TestDeactivateCmd_ExecuteFullUnprovision(t *testing.T) {
 		mockAMT := mock.NewMockInterface(ctrl)
 		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
 		mockAMT.EXPECT().Unprovision().Return(-1, errors.New("invalid AMT mode"))
+		mockAMT.EXPECT().StopConfiguration().Return(amt.StopConfigurationResponse{Status: "AMT_STATUS_SUCCESS"}, nil)
+
+		cmd := &DeactivateCmd{}
+		cmd.WSMan = mockWSMAN
+
+		err := cmd.executeFullUnprovision(&Context{AMTCommand: mockAMT})
+		assert.NoError(t, err)
+	})
+
+	t.Run("StopConfiguration rejection surfaces UnableToDeactivate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+		mockWSMAN.EXPECT().Unprovision(1).Return(setupandconfiguration.Response{}, tlsCertRequired)
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetProvisioningState().Return(provisioningStateInProvisioning, nil)
+		mockAMT.EXPECT().Unprovision().Return(-1, errors.New("invalid AMT mode"))
+		mockAMT.EXPECT().StopConfiguration().Return(amt.StopConfigurationResponse{Status: "AMT_STATUS_INVALID_AMT_MODE"}, nil)
 
 		cmd := &DeactivateCmd{}
 		cmd.WSMan = mockWSMAN

--- a/internal/lm/engine.go
+++ b/internal/lm/engine.go
@@ -84,6 +84,40 @@ func (lme *LMEConnection) StopListen() {
 	}
 }
 
+// CloseChannel sends APF_CHANNEL_CLOSE for the session's currently confirmed
+// channel so AMT releases the channel slot it allocated on OPEN_CONFIRMATION.
+// AMT's forwarded-tcpip pool is small (8 slots, SenderChannel 0..7) and it only
+// frees a slot when it sees a close, so a superseding TLS session that just
+// abandons the old channel leaks a slot for the rest of the activation; after
+// enough re-handshakes every subsequent CHANNEL_OPEN is rejected (reason 4
+// RESOURCE_SHORTAGE, or reason 1 when the rebind races the shortage).
+//
+// AMT addresses channels by its own sender number, which is what Send() uses
+// for CHANNEL_DATA, so the close must carry Session.SenderChannel too.
+//
+// Only the abandoned-channel case needs a close. A nil StreamDataBuffer means
+// apf.ProcessChannelClose already saw AMT's own CHANNEL_CLOSE for our confirmed
+// channel and cleared the stream, so the slot is already free and closing again
+// would address a channel AMT has forgotten; EnableTunnel re-arms the buffer for
+// each new session and runs after the caller's teardown, so this stays an
+// accurate "AMT has not closed us" test. Best-effort: the caller is tearing the
+// session down regardless, so a failed close is logged, not returned, and the
+// confirmed flag is cleared either way so we never send two closes for one
+// channel.
+func (lme *LMEConnection) CloseChannel() {
+	if lme.Session == nil || !lme.Session.HandshakeConfirmed || lme.Session.StreamDataBuffer == nil {
+		return
+	}
+
+	log.Debug("LME tunnel: closing superseded APF channel")
+
+	if err := lme.Command.Send(apf.BuildChannelCloseBytes(lme.Session.SenderChannel)); err != nil {
+		log.Debugf("LME tunnel: failed to close superseded APF channel: %v", err)
+	}
+
+	lme.Session.HandshakeConfirmed = false
+}
+
 // AMT advertises tcpip-forward for a management port plus a matching
 // redirection port. Which ports appear depends on whether TLS is enforced:
 //   - non-TLS device: 16992 (management) + 623 (redirection)

--- a/internal/lm/engine_test.go
+++ b/internal/lm/engine_test.go
@@ -447,3 +447,103 @@ func Test_Connect_WaitGroupManagement(t *testing.T) {
 		t.Fatal("WaitGroup counter not balanced after Connect")
 	}
 }
+
+// capturingHECIMock records every frame handed to SendMessage so channel-close
+// tests can assert on the exact bytes rpc-go puts on the wire.
+type capturingHECIMock struct {
+	sent    [][]byte
+	sendErr error
+}
+
+func (m *capturingHECIMock) Init(useLME, useWD bool) error       { return nil }
+func (m *capturingHECIMock) InitHOTHAM() error                   { return nil }
+func (m *capturingHECIMock) InitWithGUID(guid interface{}) error { return nil }
+func (m *capturingHECIMock) GetBufferSize() uint32               { return 5120 }
+func (m *capturingHECIMock) Close()                              {}
+
+func (m *capturingHECIMock) SendMessage(buffer []byte, done *uint32) (int, error) {
+	if m.sendErr != nil {
+		return 0, m.sendErr
+	}
+
+	m.sent = append(m.sent, append([]byte(nil), buffer...))
+
+	return len(buffer), nil
+}
+
+func (m *capturingHECIMock) ReceiveMessage(buffer []byte, done *uint32) (int, error) {
+	return 0, nil
+}
+
+// newCloseChannelFixture builds an LMEConnection whose session looks like a
+// confirmed tunnel channel: AMT's sender channel is 6 and the stream buffer is
+// live (i.e. AMT has NOT closed us), which is the state a superseding TLS
+// session abandons.
+func newCloseChannelFixture() (*LMEConnection, *capturingHECIMock) {
+	mock := &capturingHECIMock{}
+	lme := &LMEConnection{
+		Command: pthi.Command{Heci: mock},
+		Session: &apf.Session{
+			SenderChannel:      6,
+			RecipientChannel:   19,
+			HandshakeConfirmed: true,
+			StreamDataBuffer:   make(chan []byte, 1),
+		},
+	}
+
+	return lme, mock
+}
+
+func TestCloseChannel_SendsCloseForAMTSenderChannel(t *testing.T) {
+	lme, mock := newCloseChannelFixture()
+
+	lme.CloseChannel()
+
+	assert.Len(t, mock.sent, 1, "abandoning a confirmed channel must send exactly one CHANNEL_CLOSE")
+	assert.Equal(t, apf.BuildChannelCloseBytes(6), mock.sent[0],
+		"close must address AMT's sender channel so AMT frees the slot it allocated")
+	assert.False(t, lme.Session.HandshakeConfirmed, "confirmed flag must clear so we never double-close")
+}
+
+func TestCloseChannel_IsIdempotent(t *testing.T) {
+	lme, mock := newCloseChannelFixture()
+
+	lme.CloseChannel()
+	lme.CloseChannel()
+
+	assert.Len(t, mock.sent, 1, "a second call must not send another close for the same channel")
+}
+
+func TestCloseChannel_SkipsWhenAMTAlreadyClosed(t *testing.T) {
+	lme, mock := newCloseChannelFixture()
+	// apf.ProcessChannelClose nils StreamDataBuffer when AMT's own CHANNEL_CLOSE
+	// targets our confirmed channel; the slot is already free.
+	lme.Session.StreamDataBuffer = nil
+
+	lme.CloseChannel()
+
+	assert.Empty(t, mock.sent, "must not close a channel AMT has already torn down")
+}
+
+func TestCloseChannel_SkipsWhenNoChannelConfirmed(t *testing.T) {
+	lme, mock := newCloseChannelFixture()
+	lme.Session.HandshakeConfirmed = false
+
+	lme.CloseChannel()
+
+	assert.Empty(t, mock.sent, "no confirmed channel means there is no slot to release")
+}
+
+func TestCloseChannel_NilSessionDoesNotPanic(t *testing.T) {
+	lme := &LMEConnection{Command: pthi.Command{Heci: &capturingHECIMock{}}}
+
+	assert.NotPanics(t, lme.CloseChannel)
+}
+
+func TestCloseChannel_SendErrorIsBestEffort(t *testing.T) {
+	lme, mock := newCloseChannelFixture()
+	mock.sendErr = errors.New("heci write failed")
+
+	assert.NotPanics(t, lme.CloseChannel, "teardown must survive a failed close")
+	assert.False(t, lme.Session.HandshakeConfirmed, "state must clear even when the close fails")
+}

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -89,8 +89,6 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 	}
 
 	probeTimeout := time.Duration(utils.LMSDialerTimeout) * time.Second
-	recoveryBudget := time.Duration(utils.LMSRecoveryBudget) * time.Second
-	retryDelay := utils.LMSProbeRetryDelay * time.Millisecond
 
 	if clientParams.UseTLS {
 		clientParams.SelfSignedAllowed = tlsConfig.InsecureSkipVerify
@@ -100,8 +98,8 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 		}
 
 		conn, err := probeLMS(func(ctx context.Context) (net.Conn, error) {
-			return dialer.DialContext(ctx, "tcp", utils.LMSLoopbackAddress+":"+utils.LMSTLSPort)
-		}, probeTimeout, recoveryBudget, retryDelay)
+			return dialer.DialContext(ctx, "tcp", utils.LMSAddress+":"+utils.LMSTLSPort)
+		}, probeTimeout, utils.LMSRecoveryBudget, utils.LMSProbeRetryDelay)
 		if err != nil {
 			// A dial that was refused means LMS is genuinely down, so LME-over-HECI
 			// is the correct path. But a dial that timed out or was accepted then
@@ -138,8 +136,8 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 		dialer := &net.Dialer{}
 
 		con, err := probeLMS(func(ctx context.Context) (net.Conn, error) {
-			return dialer.DialContext(ctx, "tcp4", utils.LMSLoopbackAddress+":"+utils.LMSPort)
-		}, probeTimeout, recoveryBudget, retryDelay)
+			return dialer.DialContext(ctx, "tcp4", utils.LMSAddress+":"+utils.LMSPort)
+		}, probeTimeout, utils.LMSRecoveryBudget, utils.LMSProbeRetryDelay)
 		if err != nil {
 			// LMS up but its port did not recover: it still owns the MEI, so HECI
 			// fallback is futile. Surface the error rather than contending for /dev/mei0.
@@ -193,13 +191,29 @@ func probeLMS(dial func(context.Context) (net.Conn, error), timeout, budget, ret
 	var lastErr error
 
 	for attempt := 1; ; attempt++ {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		// Clamp the attempt to what is left of the budget: a full-length dial
+		// started near the end would overrun the budget by up to one timeout.
+		attemptTimeout := timeout
+		if remaining := time.Until(deadline); remaining < attemptTimeout {
+			attemptTimeout = remaining
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), attemptTimeout)
 		conn, err := dial(ctx)
 
 		cancel()
 
 		if err == nil {
 			return conn, nil
+		}
+
+		// A dialer can hand back a usable-looking conn alongside an error (a
+		// connect that completed but whose handshake failed). Nothing below reads
+		// it, so close it or the retry loop leaks a descriptor per attempt.
+		if conn != nil {
+			if closeErr := conn.Close(); closeErr != nil {
+				logrus.Debugf("closing LMS conn returned with dial error: %v", closeErr)
+			}
 		}
 
 		lastErr = err

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -9,8 +9,12 @@ import (
 	"context"
 	cryptotls "crypto/tls"
 	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
 	"net"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman"
@@ -85,19 +89,32 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 	}
 
 	probeTimeout := time.Duration(utils.LMSDialerTimeout) * time.Second
+	recoveryBudget := time.Duration(utils.LMSRecoveryBudget) * time.Second
+	retryDelay := utils.LMSProbeRetryDelay * time.Millisecond
 
 	if clientParams.UseTLS {
 		clientParams.SelfSignedAllowed = tlsConfig.InsecureSkipVerify
-
-		ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
-		defer cancel()
 
 		dialer := &cryptotls.Dialer{
 			Config: tlsConfig,
 		}
 
-		conn, err := dialer.DialContext(ctx, "tcp", utils.LMSAddress+":"+utils.LMSTLSPort)
+		conn, err := probeLMS(func(ctx context.Context) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", utils.LMSLoopbackAddress+":"+utils.LMSTLSPort)
+		}, probeTimeout, recoveryBudget, retryDelay)
 		if err != nil {
+			// A dial that was refused means LMS is genuinely down, so LME-over-HECI
+			// is the correct path. But a dial that timed out or was accepted then
+			// dropped means LMS is up with its TLS port stack restarting; it still
+			// owns /dev/mei0, so falling back to HECI would only contend for the MEI
+			// and fail with "device or resource busy". In that case probeLMS has
+			// already exhausted the recovery budget, so surface the error instead.
+			if errors.Is(err, errLMSUpButUnready) {
+				logrus.Errorf("LMS is up but its TLS port did not recover within the retry budget; not falling back to HECI: %v", err)
+
+				return err
+			}
+
 			logrus.Debugf("LMS TLS port not active, using LME-over-HECI with local TLS termination. LMS TLS dial error: %v", err)
 
 			g.localTransport = NewLocalTransportTLS(tlsConfig)
@@ -118,13 +135,20 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 			defer conn.Close()
 		}
 	} else {
-		ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
-		defer cancel()
-
 		dialer := &net.Dialer{}
 
-		con, err := dialer.DialContext(ctx, "tcp4", utils.LMSAddress+":"+utils.LMSPort)
+		con, err := probeLMS(func(ctx context.Context) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp4", utils.LMSLoopbackAddress+":"+utils.LMSPort)
+		}, probeTimeout, recoveryBudget, retryDelay)
 		if err != nil {
+			// LMS up but its port did not recover: it still owns the MEI, so HECI
+			// fallback is futile. Surface the error rather than contending for /dev/mei0.
+			if errors.Is(err, errLMSUpButUnready) {
+				logrus.Errorf("LMS is up but its local port did not recover within the retry budget; not falling back to HECI: %v", err)
+
+				return err
+			}
+
 			logrus.Debug("LMS not active, using local transport instead.")
 
 			g.localTransport = NewLocalTransport()
@@ -138,6 +162,118 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 	g.wsmanMessages = wsman.NewMessages(clientParams)
 
 	return nil
+}
+
+// errLMSUpButUnready indicates the LMS dial reached LMS — it either timed out or
+// was accepted then dropped mid-handshake — but LMS never became usable within
+// the recovery budget. LMS owns /dev/mei0 while it is up, so the caller must NOT
+// fall back to LME-over-HECI on this error: the MEI is unavailable and HECI
+// would only fail with "device or resource busy".
+var errLMSUpButUnready = errors.New("LMS is up but its local port is not ready")
+
+// probeLMS dials LMS to decide whether an LMS daemon is answering or the caller
+// must fall back to LME-over-HECI. The two failure classes are treated very
+// differently:
+//
+//   - A dial that fails fast (connection refused / unreachable) means LMS is
+//     genuinely down. It won't clear by waiting, so probeLMS returns the raw
+//     error immediately and the caller falls back to HECI.
+//   - A dial that times out, or is accepted then dropped mid-handshake (EOF /
+//     reset), means LMS is up but its TLS port stack is momentarily restarting
+//     (most notably right after activation). LMS still holds /dev/mei0, so a HECI
+//     fallback would only contend for the MEI and fail with "device or resource
+//     busy". probeLMS retries the dial until utils.LMSRecoveryBudget is spent and,
+//     if LMS still hasn't recovered, wraps errLMSUpButUnready so the caller keeps
+//     off HECI and surfaces a clean failure instead.
+//
+// Each attempt uses its own timeout-bound context.
+func probeLMS(dial func(context.Context) (net.Conn, error), timeout, budget, retryDelay time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(budget)
+
+	var lastErr error
+
+	for attempt := 1; ; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		conn, err := dial(ctx)
+
+		cancel()
+
+		if err == nil {
+			return conn, nil
+		}
+
+		lastErr = err
+
+		// LMS genuinely down: fall back to HECI immediately (raw error, no sentinel).
+		if !lmsUpButUnready(err) {
+			return nil, err
+		}
+
+		// LMS answered the socket but isn't serving yet. Stop once another retry
+		// would overrun the recovery budget, and tell the caller LMS is up so it
+		// does not contend for the MEI via HECI.
+		if time.Now().Add(retryDelay).After(deadline) {
+			return nil, fmt.Errorf("%w: %w", errLMSUpButUnready, lastErr)
+		}
+
+		logrus.Debugf("LMS dial did not complete (attempt %d, %v); retrying while LMS local port restarts", attempt, err)
+		time.Sleep(retryDelay)
+	}
+}
+
+// lmsUpButUnready reports whether a failed LMS dial indicates LMS is up but not
+// yet serving — a connect timeout, or a connection accepted then reset/closed
+// mid-handshake (EOF) while the AMT/LMS TLS port stack restarts. A refused or
+// otherwise fast-failing dial (LMS genuinely down) returns false.
+//
+// A timeout only implies "LMS restarting" when the dial targeted loopback,
+// where LMS actually listens. If the dial timed out against a non-loopback
+// address (e.g. "localhost" mis-resolving to a routable corporate IP), LMS was
+// never really reached, so we return false and let the caller fall back to
+// HECI instead of hard-failing after the recovery budget.
+func lmsUpButUnready(err error) bool {
+	if isDialTimeout(err) {
+		return dialTargetIsLoopback(err)
+	}
+
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET)
+}
+
+// dialTargetIsLoopback reports whether a failed dial's target address is a
+// loopback address. When the address cannot be determined from the error it
+// returns true, preserving the historical "LMS is up, keep retrying" behavior
+// for loopback dials rather than eagerly contending for the MEI over HECI.
+func dialTargetIsLoopback(err error) bool {
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) || opErr.Addr == nil {
+		return true
+	}
+
+	host, _, splitErr := net.SplitHostPort(opErr.Addr.String())
+	if splitErr != nil {
+		host = opErr.Addr.String()
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true
+	}
+
+	return ip.IsLoopback()
+}
+
+// isDialTimeout reports whether err is a dial deadline/timeout rather than a
+// fast failure such as connection refused.
+func isDialTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // Close closes any open local transport connections

--- a/internal/local/amt/wsman_test.go
+++ b/internal/local/amt/wsman_test.go
@@ -4,3 +4,216 @@
  **********************************************************************/
 
 package amt
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// timeoutErr implements net.Error with Timeout() == true.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestIsDialTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context deadline", context.DeadlineExceeded, true},
+		{"net timeout", timeoutErr{}, true},
+		{"connection refused", syscall.ECONNREFUSED, false},
+		{"generic error", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDialTimeout(tt.err))
+		})
+	}
+}
+
+// opTimeoutErr wraps a net.Error timeout in a *net.OpError carrying the dial
+// target address, mirroring what net.Dialer.DialContext returns on a real
+// connect timeout. addr is the "host:port" the dial targeted.
+func opTimeoutErr(addr string) error {
+	host, port, _ := net.SplitHostPort(addr)
+
+	return &net.OpError{
+		Op:   "dial",
+		Net:  "tcp4",
+		Addr: &net.TCPAddr{IP: net.ParseIP(host), Port: atoiOrZero(port)},
+		Err:  timeoutErr{},
+	}
+}
+
+func atoiOrZero(s string) int {
+	n := 0
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+
+		n = n*10 + int(r-'0')
+	}
+
+	return n
+}
+
+// TestLMSUpButUnready_TimeoutClassification pins the loopback gating: a dial
+// timeout only means "LMS up, keep off HECI" when the dial targeted loopback.
+// A timeout against a routable address (localhost mis-resolving to a corporate
+// IP) must NOT be read as LMS-up, so the caller can fall back to HECI.
+func TestLMSUpButUnready_TimeoutClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"loopback timeout is lms-up", opTimeoutErr("127.0.0.1:16992"), true},
+		{"routable timeout is not lms-up", opTimeoutErr("10.49.14.88:16992"), false},
+		{"bare timeout (no addr) defaults lms-up", context.DeadlineExceeded, true},
+		{"eof is lms-up regardless of addr", io.EOF, true},
+		{"reset is lms-up", syscall.ECONNRESET, true},
+		{"refused is not lms-up", syscall.ECONNREFUSED, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, lmsUpButUnready(tt.err))
+		})
+	}
+}
+
+// TestProbeLMS_RoutableTimeoutFallsBackToHECI reproduces the AMT16 local-mode
+// failure: "localhost" resolved to a rotating routable IP, so every dial timed
+// out against a host LMS never listens on. probeLMS must return the raw error
+// (not errLMSUpButUnready) so the caller falls back to HECI instead of
+// hard-failing after the recovery budget.
+func TestProbeLMS_RoutableTimeoutFallsBackToHECI(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+
+		return nil, opTimeoutErr("10.49.14.88:16992")
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.NotErrorIs(t, err, errLMSUpButUnready, "a routable-IP timeout must not claim LMS-up; caller needs HECI fallback")
+	assert.Equal(t, 1, attempts, "a non-loopback timeout is not a restart; do not burn the recovery budget retrying")
+}
+
+func TestProbeLMS_SuccessNoRetry(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+
+		return &net.TCPConn{}, nil
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	assert.Equal(t, 1, attempts, "success must not retry")
+}
+
+func TestProbeLMS_RefusedFailsFast(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+
+		return nil, syscall.ECONNREFUSED
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.Equal(t, 1, attempts, "a refused dial (LMS down) must not be retried")
+}
+
+func TestProbeLMS_TimeoutRetriesThenGivesUp(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+
+		return nil, context.DeadlineExceeded
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.ErrorIs(t, err, errLMSUpButUnready, "an exhausted timeout must signal LMS-up so the caller skips HECI")
+	assert.Greater(t, attempts, 1, "a timeout must be retried, not fail on the first attempt")
+}
+
+// TestProbeLMS_EOFTreatedAsLMSUp reproduces the AMT21 LMS log: the LMS TLS dial
+// is accepted then dropped with EOF while the AMT/LMS port stack restarts. That
+// means LMS is up and owns the MEI, so probeLMS must retry and ultimately signal
+// errLMSUpButUnready rather than returning a raw error that triggers HECI fallback.
+func TestProbeLMS_EOFTreatedAsLMSUp(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+
+		return nil, io.EOF
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.ErrorIs(t, err, errLMSUpButUnready, "an EOF dial means LMS is up; caller must not fall back to HECI")
+	assert.ErrorIs(t, err, io.EOF, "the underlying dial error should remain wrapped")
+	assert.Greater(t, attempts, 1, "an EOF dial must be retried while LMS restarts")
+}
+
+// TestProbeLMS_EOFThenSuccess verifies that once LMS finishes restarting, a
+// subsequent successful dial is returned and no LMS-up error is surfaced.
+func TestProbeLMS_EOFThenSuccess(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+		if attempts < 2 {
+			return nil, io.EOF
+		}
+
+		return &net.TCPConn{}, nil
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	assert.Equal(t, 2, attempts, "should stop retrying once LMS answers")
+}
+
+func TestProbeLMS_TimeoutThenSuccess(t *testing.T) {
+	attempts := 0
+
+	conn, err := probeLMS(func(context.Context) (net.Conn, error) {
+		attempts++
+		if attempts < 2 {
+			return nil, timeoutErr{}
+		}
+
+		return &net.TCPConn{}, nil
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	assert.Equal(t, 2, attempts, "should stop retrying once LMS answers")
+}

--- a/internal/local/amt/wsman_test.go
+++ b/internal/local/amt/wsman_test.go
@@ -217,3 +217,71 @@ func TestProbeLMS_TimeoutThenSuccess(t *testing.T) {
 	assert.NotNil(t, conn)
 	assert.Equal(t, 2, attempts, "should stop retrying once LMS answers")
 }
+
+// trackedConn records whether it was closed. It embeds net.TCPConn only to
+// satisfy net.Conn; none of the embedded methods are called.
+type trackedConn struct {
+	net.TCPConn
+
+	closed bool
+}
+
+func (c *trackedConn) Close() error {
+	c.closed = true
+
+	return nil
+}
+
+// TestProbeLMS_ClosesConnReturnedWithError covers a dialer that hands back a
+// usable-looking conn alongside an error (a connect that completed but whose
+// handshake failed). Nothing reads that conn, so probeLMS must close it or the
+// retry loop leaks a descriptor per attempt for the whole recovery budget.
+func TestProbeLMS_ClosesConnReturnedWithError(t *testing.T) {
+	var conns []*trackedConn
+
+	_, err := probeLMS(func(context.Context) (net.Conn, error) {
+		c := &trackedConn{}
+		conns = append(conns, c)
+
+		return c, io.EOF
+	}, time.Millisecond, 5*time.Millisecond, time.Millisecond)
+
+	require.Error(t, err)
+	require.NotEmpty(t, conns, "dial should have been attempted")
+
+	for i, c := range conns {
+		assert.True(t, c.closed, "conn from attempt %d returned with an error was not closed", i+1)
+	}
+}
+
+// TestProbeLMS_DoesNotOverrunBudget pins the per-attempt timeout clamp: with a
+// dial timeout far larger than the remaining budget, an unclamped attempt would
+// block for the full dial timeout past the deadline.
+func TestProbeLMS_DoesNotOverrunBudget(t *testing.T) {
+	const (
+		dialTimeout = 500 * time.Millisecond
+		budget      = 50 * time.Millisecond
+		retryDelay  = time.Millisecond
+	)
+
+	start := time.Now()
+
+	// Block until the context the probe supplies expires, so the attempt lasts
+	// exactly as long as probeLMS allows it to.
+	_, err := probeLMS(func(ctx context.Context) (net.Conn, error) {
+		<-ctx.Done()
+
+		return nil, ctx.Err()
+	}, dialTimeout, budget, retryDelay)
+
+	elapsed := time.Since(start)
+
+	// Clamped, the single attempt ends with the budget (~50ms). Unclamped it runs
+	// the full dial timeout (~500ms). The bound sits well between the two so slow
+	// CI machines do not flake it.
+	const slack = 200 * time.Millisecond
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, budget+slack,
+		"probe overran its budget by a full dial timeout; per-attempt timeout is not clamped to the remaining budget")
+}

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -945,6 +945,12 @@ func (e *Executor) stopLMEListen(lmec *lm.LMEConnection) {
 	}
 
 	e.lmeListenDone = nil
+
+	// Release AMT's channel slot now that no reader is left on it. AMT only
+	// frees a forwarded-tcpip slot when it sees a close, and its pool is 8
+	// slots deep, so skipping this leaks one slot per superseding TLS session
+	// and later CHANNEL_OPENs are rejected for resource shortage.
+	lmec.CloseChannel()
 }
 
 func (e *Executor) stopLMEForwarder() {

--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -52,6 +52,8 @@ const (
 	// GUID-targeted clients (InitWithGUID / InitHOTHAM). These paths are not
 	// EBUSY-tuned like initLocked; a small fixed number of attempts is enough.
 	guidConnectAttempts = 3
+	// heciWriteBusyAttempts bounds the EBUSY retry loop around a HECI write.
+	heciWriteBusyAttempts = 3
 )
 
 // PTHI
@@ -176,11 +178,18 @@ func (heci *Driver) initLocked(useLME, useWD bool) error {
 			break
 		}
 
-		log.Warnf("mei connect busy, retry %d", i+1)
+		// Per-attempt busy is an expected transient (the ME settles within a few
+		// retries); log at debug so it only shows under -v. The exhausted-ladder
+		// case below emits a single warning.
+		log.Debugf("mei connect busy, retry %d", i+1)
 		time.Sleep(time.Duration(i+1) * utils.HeciConnectRetryBackoff * time.Millisecond)
 	}
 
 	if err != nil {
+		if errors.Is(err, syscall.EBUSY) {
+			log.Warnf("mei connect still busy after %d attempts", heciConnectAttempts)
+		}
+
 		return err
 	}
 
@@ -340,8 +349,9 @@ func (heci *Driver) SendMessage(buffer []byte, done *uint32) (bytesWritten int, 
 
 		// Increase EBUSY retry attempts from 1 to 3 with exponential backoff.
 		if errors.Is(err, syscall.EBUSY) {
-			for attempt := 0; attempt < 3; attempt++ {
-				log.Warnf("mei write busy, retrying (attempt %d/3)", attempt+1)
+			for attempt := 0; attempt < heciWriteBusyAttempts; attempt++ {
+				// Expected transient; debug-only so it doesn't spam without -v.
+				log.Debugf("mei write busy, retrying (attempt %d/%d)", attempt+1, heciWriteBusyAttempts)
 				delay := time.Duration(attempt+1) * utils.HeciRetryDelay * time.Millisecond
 				time.Sleep(delay)
 
@@ -361,6 +371,10 @@ func (heci *Driver) SendMessage(buffer []byte, done *uint32) (bytesWritten int, 
 				if !errors.Is(err, syscall.EBUSY) {
 					break
 				}
+			}
+
+			if errors.Is(err, syscall.EBUSY) {
+				log.Warnf("mei write still busy after %d attempts", heciWriteBusyAttempts)
 			}
 		}
 

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -22,6 +22,13 @@ const (
 
 	// LMSAddress is used for determining what address to connect to LMS on
 	LMSAddress = "localhost"
+	// LMSLoopbackAddress is the literal loopback IP the local LMS probe dials.
+	// LMS only ever listens on loopback, so the probe must not go through host
+	// resolution: on some managed devices "localhost" resolves via DNS to
+	// rotating routable corporate IPs (observed: 10.49.x / 10.99.x), and dialing
+	// those times out, is misread as "LMS up but restarting", and blocks the
+	// HECI fallback. Dialing 127.0.0.1 directly sidesteps resolution entirely.
+	LMSLoopbackAddress = "127.0.0.1"
 	// LMSPort is used for determining what port to connect to LMS on
 	LMSPort    = "16992"
 	LMSTLSPort = "16993"
@@ -32,8 +39,18 @@ const (
 	MPSServerMaxLength = 256
 
 	// LMSConnectionTimeout is the maximum wait for LMS TCP connection setup.
-	LMSConnectionTimeout    = 5    // seconds
-	LMSDialerTimeout        = 5    // seconds
+	LMSConnectionTimeout = 5 // seconds
+	LMSDialerTimeout     = 5 // seconds
+	// LMSRecoveryBudget bounds the wall-clock time SetupWsmanClient keeps retrying
+	// the LMS dial before giving up. A refused connection (LMS genuinely down)
+	// fails fast and does not consume the budget; only a dial that times out or is
+	// accepted-then-dropped (LMS up but its TLS port stack restarting, e.g. right
+	// after activation) is retried. While LMS is up it owns /dev/mei0, so falling
+	// back to LME-over-HECI would only contend for the MEI and fail with "device
+	// or resource busy" - the caller waits out the restart on the LMS path instead.
+	LMSRecoveryBudget = 30 // seconds
+	// LMSProbeRetryDelay is the wait between LMS dial retries.
+	LMSProbeRetryDelay      = 1000 // milliseconds
 	HeciReadTimeout         = 3    // seconds
 	HeciRetryDelay          = 1500 // milliseconds
 	HeciReinitDelay         = 300  // milliseconds

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -4,12 +4,29 @@
  **********************************************************************/
 package utils
 
+import "time"
+
 type ReturnCode int
 
 var (
 	ProjectVersion string = "Development Build"
 	BuildDate      string = "unknown"
 	BuildCommit    string = "unknown"
+)
+
+// LMS probe timings. Typed as durations so call sites use them directly rather
+// than re-deriving the unit from a comment.
+const (
+	// LMSRecoveryBudget bounds the wall-clock time SetupWsmanClient keeps retrying
+	// the LMS dial before giving up. A refused connection (LMS genuinely down)
+	// fails fast and does not consume the budget; only a dial that times out or is
+	// accepted-then-dropped (LMS up but its TLS port stack restarting, e.g. right
+	// after activation) is retried. While LMS is up it owns /dev/mei0, so falling
+	// back to LME-over-HECI would only contend for the MEI and fail with "device
+	// or resource busy" - the caller waits out the restart on the LMS path instead.
+	LMSRecoveryBudget = 30 * time.Second
+	// LMSProbeRetryDelay is the wait between LMS dial retries.
+	LMSProbeRetryDelay = 1 * time.Second
 )
 
 const (
@@ -20,15 +37,18 @@ const (
 	// ClientName is the name of the exectable
 	ClientName = "RPC"
 
-	// LMSAddress is used for determining what address to connect to LMS on
-	LMSAddress = "localhost"
-	// LMSLoopbackAddress is the literal loopback IP the local LMS probe dials.
-	// LMS only ever listens on loopback, so the probe must not go through host
-	// resolution: on some managed devices "localhost" resolves via DNS to
-	// rotating routable corporate IPs (observed: 10.49.x / 10.99.x), and dialing
-	// those times out, is misread as "LMS up but restarting", and blocks the
-	// HECI fallback. Dialing 127.0.0.1 directly sidesteps resolution entirely.
-	LMSLoopbackAddress = "127.0.0.1"
+	// LMSAddress is the address used to connect to LMS. It is the literal loopback
+	// IP rather than "localhost" because LMS only ever listens on loopback and the
+	// dial must not go through host resolution: on some managed devices
+	// "localhost" resolves via DNS to rotating routable corporate IPs (observed:
+	// 10.49.x / 10.99.x), and dialing those times out, is misread as "LMS up but
+	// restarting", and blocks the HECI fallback. Dialing 127.0.0.1 sidesteps
+	// resolution entirely.
+	//
+	// This must stay the same value the LMS probe dials — a probe against loopback
+	// while the WSMAN client targets a resolved name would confirm one endpoint and
+	// then talk to another.
+	LMSAddress = "127.0.0.1"
 	// LMSPort is used for determining what port to connect to LMS on
 	LMSPort    = "16992"
 	LMSTLSPort = "16993"
@@ -39,18 +59,8 @@ const (
 	MPSServerMaxLength = 256
 
 	// LMSConnectionTimeout is the maximum wait for LMS TCP connection setup.
-	LMSConnectionTimeout = 5 // seconds
-	LMSDialerTimeout     = 5 // seconds
-	// LMSRecoveryBudget bounds the wall-clock time SetupWsmanClient keeps retrying
-	// the LMS dial before giving up. A refused connection (LMS genuinely down)
-	// fails fast and does not consume the budget; only a dial that times out or is
-	// accepted-then-dropped (LMS up but its TLS port stack restarting, e.g. right
-	// after activation) is retried. While LMS is up it owns /dev/mei0, so falling
-	// back to LME-over-HECI would only contend for the MEI and fail with "device
-	// or resource busy" - the caller waits out the restart on the LMS path instead.
-	LMSRecoveryBudget = 30 // seconds
-	// LMSProbeRetryDelay is the wait between LMS dial retries.
-	LMSProbeRetryDelay      = 1000 // milliseconds
+	LMSConnectionTimeout    = 5    // seconds
+	LMSDialerTimeout        = 5    // seconds
 	HeciReadTimeout         = 3    // seconds
 	HeciRetryDelay          = 1500 // milliseconds
 	HeciReinitDelay         = 300  // milliseconds


### PR DESCRIPTION
**Fixed bugs: #1460. Completes #1461 (part 2).**

> **Depends on** [PR1464](https://github.com/device-management-toolkit/rpc-go/pull/1464) (`fix/orchestration-robustness`) — review/merge that first.

5 commits.

### `fix(local): harden LMS probe with retry budget and loopback dial` (`9e699c8`)
Two failure modes right after activation, when LMS is up but its TLS port stack
is momentarily restarting:
- `probeLMS` treated **any** dial error as "LMS down" and fell back to
  LME-over-HECI — but LMS still owns `/dev/mei0` while up, so the fallback
  contended for the MEI (`device or resource busy`). Now it distinguishes classes:
  connection **refused** → LMS down, HECI immediately; **timeout /
  accepted-then-dropped** → LMS up, retried within a wall-clock budget
  (`LMSRecoveryBudget` = 30s). If it never recovers, it wraps `errLMSUpButUnready`
  so `SetupWsmanClient` surfaces a clean failure instead of MEI contention.
  Replaces the old `LMSProbeAttempts` count cap with budget/retry-delay constants.
- The probe dialed `utils.LMSAddress`, which was `"localhost"` and on some devices
  resolves via DNS to rotating routable corporate IPs (observed on AMT16) that LMS
  never listens on — so every dial timed out, was misclassified "LMS up", and
  retried the wrong address for the full budget before refusing HECI. The probe
  now dials loopback directly, and the timeout branch of `lmsUpButUnready` is
  gated on the dial target being loopback (timeout against a non-loopback address
  ⇒ LMS never reached ⇒ fall back to HECI). Errors without a `net.OpError` address
  keep the historical loopback-assumed behavior. `0b8231c` (below) finished the
  job by making `LMSAddress` itself the loopback IP, so the probe and the WSMAN
  client can no longer target different endpoints.

```mermaid
flowchart TD
    A[probeLMS: dial 127.0.0.1:16992/16993<br/>per-attempt timeout clamped to<br/>remaining budget] --> B{dial outcome}
    B -->|connection refused fast| C[LMS down<br/>fall back to HECI immediately]
    B -->|timeout / accepted-then-dropped<br/>on loopback| D[LMS up but restarting]
    B -->|timeout on non-loopback addr| C
    D --> E{within LMSRecoveryBudget 30s?}
    E -->|retry succeeds| OK[use LMS/WSMAN]
    E -->|budget exhausted| G[wrap errLMSUpButUnready<br/>clean failure, no MEI contention]
    C:::heci
    OK:::ok
    G:::bad
    classDef ok fill:#1f7a1f,color:#fff
    classDef bad fill:#a11,color:#fff
    classDef heci fill:#248,color:#fff
```

### `perf(heci): quiet transient mei-busy retries, warn on exhaustion` (`4748821`)
`mei connect busy` / `mei write busy` per-attempt retries are an expected
transient (ME settles within a few retries) but were logged at `warn`, spamming
every local activation. Dropped to `debug` (visible under `-v`); a single `warn`
is emitted only on exhausted retries. Extracts `heciWriteBusyAttempts`.

### `fix(local): recover incomplete ACM configuration` (`92180bc`)
`recoverInProvisioningOverHECI` gave up as soon as the HECI `Unprovision` call
failed. On a device wedged mid-ACM-configuration the firmware rejects
`Unprovision` outright, so deactivate returned `UnableToDeactivate` and left the
device stuck with no way forward short of a power cycle.

Now a failed `Unprovision` falls through to `StopConfiguration`, which is the
call the firmware accepts in that state. The firmware's own status decides the
outcome: only `AMT_STATUS_SUCCESS` reports success, anything else still returns
`UnableToDeactivate`. Status is read from the response rather than inferred from
the absence of an error — the same firmware-status-over-assumption rule PR1
establishes. This completes #1461, whose first half (`e3482f6` + `9125bc0`) landed
in PR2.

### `fix(lme): close superseded APF channel to free AMT slots` (`5ea59d0`)
In LME TLS-tunnel mode a ClientHello supersede retired our listener and forwarder
but never sent `APF_CHANNEL_CLOSE` for the channel AMT had confirmed. AMT frees a
`forwarded-tcpip` slot only when it sees a close, and its pool is **8 slots deep**
(SenderChannel 0..7) — so every re-handshake leaked one slot for the rest of the
activation. Once drained, `CHANNEL_OPEN` was rejected and remote ACM activation
failed late.

Three consecutive hardware runs reproduced this, all in LME mode with an ACM
profile.
Reconstructing slot occupancy by pairing `OPEN_CONFIRMATION` against
`CHANNEL_CLOSE` shows every fatal open failure sitting at 6–7 of 8 slots leaked,
while the survivable rejects happened at zero slots held. That is why reason 4
(`RESOURCE_SHORTAGE`) and reason 1 are the same bug: retiming a retry cannot free
a slot that was never released.

Adds `LMEConnection.CloseChannel`, called from `stopLMEListen` once the listener
has exited. It addresses AMT's sender channel — matching what `Send` uses for
`CHANNEL_DATA` — and skips the close when `StreamDataBuffer` is already nil,
because AMT closed the channel itself and the slot is already free. Best-effort
by design: teardown proceeds either way.

Only `prepareLMETunnel` reaches this path, so **the plain LMS relay and the
non-tunnel LME path are unaffected**.

### `fix(local): dial one LMS address and keep the probe inside its budget` (`0b8231c`)
Review follow-up, four items:
- **One address.** The probe dialed `LMSLoopbackAddress` (`127.0.0.1`) while the
  WSMAN client still targeted `LMSAddress` (`"localhost"`), so the probe could
  confirm one endpoint and the client then talk to another — the exact
  mis-resolution the loopback dial was added to prevent. The two constants are
  collapsed: `LMSAddress` **is** the loopback IP and `LMSLoopbackAddress` is gone.
  Callers concatenate or `net.JoinHostPort` the constant, so both forms are
  IP-safe. TLS caveat: with `--skip-amt-cert-check=false`, Go now verifies against
  an IP SAN rather than the name `localhost`; AMT certificates carry the device
  FQDN, so that path fails either way today, and activation runs with
  `InsecureSkipVerify`.
- **Typed durations.** `LMSRecoveryBudget` and `LMSProbeRetryDelay` are
  `time.Duration` constants instead of bare numbers with a unit in a comment,
  matching the existing `lmsVersionTimeout` pattern; the call-site conversions are
  gone.
- **No descriptor leak.** A dialer can hand back a usable-looking `net.Conn`
  alongside an error (a connect that completed but whose handshake failed).
  Nothing reads it, so the probe now closes it — otherwise the retry loop leaked
  one descriptor per attempt for the whole recovery budget.
- **No budget overrun.** Each attempt's timeout is clamped to the remaining
  budget, so the probe can no longer exceed `LMSRecoveryBudget` by up to a full
  dial timeout.

**Deferred:** extracting the duplicated probe/fallback control flow shared by the
TLS and non-TLS branches of `SetupWsmanClient`. It is a behaviour-neutral refactor
of the one function on this stack's hardware-critical path, so it is queued as a
follow-up `refactor:` PR (no release impact) rather than mixed into a `fix:`.

**Out of scope:** the manual-test observation that on Windows LMS crashes after a
local ACM deactivation and needs a restart before the next ACM activation. Nothing
in this stack touches the Windows LMS service lifecycle; it warrants its own issue.

## Acceptance
The LMS probe distinguishes failure classes, dials a single loopback address
shared with the WSMAN client, closes conns returned alongside errors and stays
inside its budget — so no MEI contention, no wrong-address retries, no descriptor
leak and no overrun; transient mei-busy retries are quiet with a single warn on
exhaustion; a device wedged mid-ACM-configuration is recoverable via
`StopConfiguration` with the firmware's status deciding the outcome; and a
superseded APF channel is closed so AMT's 8-slot pool is not leaked across
re-handshakes.

```
 internal/commands/deactivate.go      |  30 ++++--
 internal/commands/deactivate_test.go |  31 +++++-
 internal/lm/engine.go                |  34 +++++++
 internal/lm/engine_test.go           | 100 ++++++++++++++++++
 internal/local/amt/wsman.go          | 166 ++++++++++++++++++++++++++++++--
 internal/local/amt/wsman_test.go     | 281 +++++++++++++++++++++++++++++++++++
 internal/rps/executor.go             |   6 ++
 pkg/heci/linux.go                    |  20 +++-
 pkg/utils/constants.go               |  31 +++++-
 9 files changed, 676 insertions(+), 23 deletions(-)
```

---

# Test report — hardware regression run (full stack)

> **Scope:** this report is for the **complete stack (PR1–PR4 combined)**, at the
> PR4 tip. The intermediate branches were **not** run against hardware
> individually; per-PR evidence is the unit/integration test suite
> (`go test ./...`), which passes on every branch, along with `gofmt -s -l` clean
> and `golangci-lint run ./...` reporting zero issues. Treat these numbers as
> validating the integrated end state each PR contributes to, not the isolated
> branch.

Full activate → configure → deactivate cycles against real AMT hardware, run in
both transport modes (**LMS** = local management service on :16992/:16993;
**LME** = in-band HECI/APF tunnel), with both local and remote profiles.

Run of 2026-08-10, on branch `fix/lms-transport-reliability` at commit `5b66952`
— a content-identical tree to the pushed PR4 tip `0b8231c` (`git diff` between the
two is empty).

| Metric | Value |
|---|---|
| Total cycles | 10 |
| Unique hosts | 5 |
| Cycles passed | **10 / 10** |
| Local passed | 10 / 10 |
| Remote passed | 10 / 10 |
| Total runtime | 25m 00s |

| Profile | Passed | Failed | Avg activate | Avg deactivate |
|---|---|---|---|---|
| local/acm | 10 | 0 | 19s | 9s |
| local/ccm | 10 | 0 | 15s | 8s |
| remote/acm | 10 | 0 | 273s | 17s |
| remote/ccm | 10 | 0 | 221s | 17s |

## Per-host results (activate / deactivate seconds) on Linux

Hosts are anonymized; only AMT version and SKU are relevant. (activation and deactivation time in sec)

| Host | Mode | L:acm | L:ccm | R:acm | R:ccm |
|---|---|---|---|---|---|
| AMT16 (16.1.27, vpro) | LME | PASS 26/7 | PASS 7/7 | PASS 230/7 | PASS 181/8 |
| AMT16 (16.1.27, vpro) | LMS | PASS 9/7 | PASS 8/6 | PASS 153/8 | PASS 133/8 |
| AMT19 (19.0.11, vpro) | LME | PASS 13/11 | PASS 17/9 | PASS 317/23 | PASS 270/23 |
| AMT19 (19.0.11, vpro) | LMS | PASS 16/10 | PASS 19/11 | PASS 273/23 | PASS 217/21 |
| AMT20 (20.0.5, ISM)   | LME | PASS 22/11 | PASS 19/9 | PASS 329/19 | PASS 248/18 |
| AMT20 (20.0.5, ISM)   | LMS | PASS 27/11 | PASS 23/10 | PASS 272/21 | PASS 213/21 |
| AMT20 (20.0.5, vpro)  | LME | PASS 24/10 | PASS 20/10 | PASS 304/19 | PASS 246/19 |
| AMT20 (20.0.5, vpro)  | LMS | PASS 30/11 | PASS 24/10 | PASS 276/20 | PASS 215/20 |
| AMT21 (21.0.6, vpro)  | LME | PASS 15/10 | PASS 10/8 | PASS 314/20 | PASS 285/20 |
| AMT21 (21.0.6, vpro)  | LMS | PASS 17/9 | PASS 12/8 | PASS 270/19 | PASS 210/19 |

Every host passes in both LMS and LME modes, for both ACM and CCM profiles,
local and remote. These are the exact firmware generations (16 / 19 / 20 / 21)
that previously exhibited the false-success and false-failure symptoms this stack
fixes (AMT16 plain-relay + localhost-misresolution, AMT19/20/21 post-commit
port-stack restart).

### Verification status of the short-read fix (`e66dd7f`)

Stated plainly, because it is the newest change in the stack: this run is a clean
regression pass, **not** a positive reproduction of the fixed path. The AMT20 ISM
host that produced the original `unexpected EOF` failure passed here, but its log
took the older `apf.ErrChannelOpenFailure` route, which the code already matched
before this commit. The signature that would prove the new sentinel is doing work
— `unexpected EOF` with **no** APF open-failure in the same log **and** the HECI
recovery path firing — has not yet appeared on hardware. It reproduces in roughly
1 in 6 LME ACM cycles, so more cycles on that host are the way to catch it. The
logic itself is pinned by unit tests (`TestIsConnectionResetErr` now asserts the
exact `url.Error`-wrapped short read the transport emits, verified to fail without
the production change).

> Confidential deployment details (host IPs, credentials, usernames) are
> intentionally omitted; hosts are labeled by AMT version and SKU only.
