### PR TITLE
feat: warn when credentials passed via CLI flags

### DIFF
--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -82,6 +84,75 @@ func (a *ServerAuthFlags) ValidateRequired(required bool) error {
 	}
 
 	return fmt.Errorf("authentication is required: provide --auth-token or --auth-username and --auth-password")
+}
+
+// AfterApply runs after Kong binds flags and prints security warnings if needed.
+// This hook is called automatically by Kong's lifecycle after flag parsing completes.
+func (a *ServerAuthFlags) AfterApply() error {
+	a.WarnIfInsecure()
+
+	return nil
+}
+
+// WarnIfInsecure prints a deprecation warning if credentials were passed via CLI flags
+// instead of environment variables. Credentials passed on the command line are visible
+// in process listings (ps, htop, /proc/<pid>/cmdline), which is a security risk.
+func (a *ServerAuthFlags) WarnIfInsecure() {
+	// Check if credentials are present (from any source)
+	hasToken := strings.TrimSpace(a.AuthToken) != ""
+	hasUsername := strings.TrimSpace(a.AuthUsername) != ""
+	hasPassword := strings.TrimSpace(a.AuthPassword) != ""
+
+	if !hasToken && !hasUsername && !hasPassword {
+		return // No credentials, no warning needed
+	}
+
+	// Helper to detect if a flag was explicitly passed on the command line
+	flagPresent := func(name string) bool {
+		prefix := name + "="
+		for _, arg := range os.Args[1:] {
+			if arg == name || strings.HasPrefix(arg, prefix) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// Detect whether credentials were explicitly passed via CLI flags
+	var cliFlags []string
+
+	if hasToken && flagPresent("--auth-token") {
+		cliFlags = append(cliFlags, "--auth-token")
+	}
+
+	if hasUsername && flagPresent("--auth-username") {
+		cliFlags = append(cliFlags, "--auth-username")
+	}
+
+	if hasPassword && flagPresent("--auth-password") {
+		cliFlags = append(cliFlags, "--auth-password")
+	}
+
+	if len(cliFlags) > 0 {
+		const separator = "-------------------------------------------------------------------"
+
+		logrus.Warnf(separator)
+		logrus.Warnf("SECURITY WARNING: Credentials passed via CLI flags (%s)", strings.Join(cliFlags, ", "))
+		logrus.Warn("These are visible in process listings and may be captured in system logs.")
+		logrus.Warn("Use environment variables instead:")
+
+		if flagPresent("--auth-token") {
+			logrus.Warn("  AUTH_TOKEN=<your-token>")
+		}
+
+		if flagPresent("--auth-username") || flagPresent("--auth-password") {
+			logrus.Warn("  AUTH_USERNAME=<username>")
+			logrus.Warn("  AUTH_PASSWORD=<password>")
+		}
+
+		logrus.Warnf(separator)
+	}
 }
 
 // ApplyToRequest sets the appropriate Authorization header on the request if any auth is provided.

--- a/internal/commands/auth_test.go
+++ b/internal/commands/auth_test.go
@@ -6,10 +6,14 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -219,4 +223,175 @@ func TestServerAuthFlags_ApplyToRequest(t *testing.T) {
 			assert.Equal(t, tt.wantHeader, req.Header.Get("Authorization"))
 		})
 	}
+}
+
+func TestServerAuthFlags_WarnIfInsecure(t *testing.T) {
+	tests := []struct {
+		name          string
+		flags         ServerAuthFlags
+		cliArgs       []string
+		expectWarning bool
+		description   string
+	}{
+		{
+			name:          "token from env - no warning",
+			flags:         ServerAuthFlags{AuthToken: "env-token"},
+			cliArgs:       []string{"rpc", "version"}, // No auth flags
+			expectWarning: false,
+			description:   "Token from environment variable should not warn",
+		},
+		{
+			name:          "token from CLI - warning",
+			flags:         ServerAuthFlags{AuthToken: "cli-token"},
+			cliArgs:       []string{"rpc", "version", "--auth-token", "cli-token"},
+			expectWarning: true,
+			description:   "Token from CLI flag should warn",
+		},
+		{
+			name: "basic auth from env - no warning",
+			flags: ServerAuthFlags{
+				AuthUsername: "user",
+				AuthPassword: "pass",
+			},
+			cliArgs:       []string{"rpc", "version"}, // No auth flags
+			expectWarning: false,
+			description:   "Basic auth from environment should not warn",
+		},
+		{
+			name: "basic auth from CLI - warning",
+			flags: ServerAuthFlags{
+				AuthUsername: "user",
+				AuthPassword: "pass",
+			},
+			cliArgs:       []string{"rpc", "version", "--auth-username", "user", "--auth-password", "pass"},
+			expectWarning: true,
+			description:   "Basic auth from CLI should warn",
+		},
+		{
+			name: "only password on CLI - partial warning",
+			flags: ServerAuthFlags{
+				AuthUsername: "user",
+				AuthPassword: "pass",
+			},
+			cliArgs:       []string{"rpc", "version", "--auth-password", "pass"},
+			expectWarning: true,
+			description:   "Password from CLI should warn even if username from env",
+		},
+		{
+			name:          "no credentials - no warning",
+			flags:         ServerAuthFlags{},
+			cliArgs:       []string{"rpc", "version"},
+			expectWarning: false,
+			description:   "No credentials should not warn",
+		},
+		{
+			name: "username only from CLI - warning",
+			flags: ServerAuthFlags{
+				AuthUsername: "user",
+			},
+			cliArgs:       []string{"rpc", "version", "--auth-username", "user"},
+			expectWarning: true,
+			description:   "Username only from CLI should warn",
+		},
+		{
+			name: "password only from CLI - warning",
+			flags: ServerAuthFlags{
+				AuthPassword: "pass",
+			},
+			cliArgs:       []string{"rpc", "version", "--auth-password", "pass"},
+			expectWarning: true,
+			description:   "Password only from CLI should warn",
+		},
+		{
+			name: "token from CLI even with env vars set - warning",
+			flags: ServerAuthFlags{
+				AuthToken: "cli-token",
+			},
+			cliArgs:       []string{"rpc", "version", "--auth-token", "cli-token"},
+			expectWarning: true,
+			description:   "Token from CLI should warn even if AUTH_TOKEN env var is also set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore os.Args
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+
+			// Set os.Args to simulate CLI invocation
+			os.Args = tt.cliArgs
+
+			// Capture log output
+			var logBuf bytes.Buffer
+
+			originalOutput := logrus.StandardLogger().Out
+			originalLevel := logrus.GetLevel()
+
+			logrus.SetOutput(&logBuf)
+			logrus.SetLevel(logrus.WarnLevel) // Ensure warnings are logged
+
+			defer func() {
+				logrus.SetOutput(originalOutput)
+				logrus.SetLevel(originalLevel)
+			}()
+
+			// Call the warning function
+			tt.flags.WarnIfInsecure()
+
+			// Check if warning was logged
+			logOutput := logBuf.String()
+			hasWarning := strings.Contains(logOutput, "SECURITY WARNING")
+
+			if hasWarning != tt.expectWarning {
+				t.Errorf("%s: expected warning=%v, got warning=%v\nLog output:\n%s",
+					tt.description, tt.expectWarning, hasWarning, logOutput)
+			}
+
+			// If we expect a warning, verify it contains key elements
+			if tt.expectWarning {
+				assert.Contains(t, logOutput, "SECURITY WARNING", "Warning should contain security notice")
+				assert.Contains(t, logOutput, "visible in process listings", "Warning should mention process visibility")
+				assert.Contains(t, logOutput, "Use environment variables instead", "Warning should suggest env vars")
+			}
+		})
+	}
+}
+
+func TestServerAuthFlags_AfterApply(t *testing.T) {
+	// Save and restore os.Args
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	// Simulate CLI with auth token
+	os.Args = []string{"rpc", "version", "--auth-token", "test-token"}
+
+	// Test that AfterApply calls WarnIfInsecure
+	flags := ServerAuthFlags{
+		AuthToken: "test-token",
+	}
+
+	// Capture log output
+	var logBuf bytes.Buffer
+
+	originalOutput := logrus.StandardLogger().Out
+	originalLevel := logrus.GetLevel()
+
+	logrus.SetOutput(&logBuf)
+	logrus.SetLevel(logrus.WarnLevel)
+
+	defer func() {
+		logrus.SetOutput(originalOutput)
+		logrus.SetLevel(originalLevel)
+	}()
+
+	// Call AfterApply
+	err := flags.AfterApply()
+
+	// Should not return error
+	assert.NoError(t, err, "AfterApply should not return error")
+
+	// Should have triggered warning
+	logOutput := logBuf.String()
+	assert.Contains(t, logOutput, "SECURITY WARNING", "AfterApply should trigger warning for CLI credentials")
 }


### PR DESCRIPTION
* Add warning when users pass authentication credentials via --auth-token, --auth-username, or --auth-password flags.
* These flags expose secrets in process listings (ps, htop, /proc), creating a security risk in multi-user environments.

WARNS when:

✅ --auth-token on command line
✅ --auth-username and/or --auth-password on command line

NO WARN when:

❌ AUTH_TOKEN environment variable
❌ AUTH_USERNAME + AUTH_PASSWORD environment variables
❌ No authentication used
Important: Use sudo -E (capital E) to preserve environment variables when running with sudo!

Setup

Run on the host machine
```bash
TOKEN=$(curl -sk https://localhost:8181/api/v1/authorize -H "Content-Type: application/json" -d '{"username":"<username>","password":"<password>"}' | jq -r '.token')
echo $TOKEN
```

Export on edge node

```bash
export AUTH_TOKEN="eyJh..."
export AUTH_USERNAME=<username>
export AUTH_PASSWORD="<password>"
```

Confirm the values are set

```bash
echo $AUTH_TOKEN
echo $AUTH_USERNAME
echo $AUTH_PASSWORD
```

# Commands that WILL SHOW WARNING (Insecure - credentials on CLI)
All of these pass credentials via CLI flags, so they're visible in ps:

Basic auth on CLI
```bash
sudo ./rpc version --auth-username <username> --auth-password '<password>'
```

Token on CLI (token value visible in ps after expansion)

```bash
sudo ./rpc version --auth-token $AUTH_TOKEN

sudo ./rpc activate --url "https://<host-ip>:8181/api/v1/admin/profiles/export/<acm-profile-name>?domainName=<domain-name>" --auth-token $AUTH_TOKEN --skip-cert-check

sudo ./rpc amtinfo --sync --url https://<host-ip>:8181/api/v1/devices --auth-token $AUTH_TOKEN --skip-cert-check
```

Username/Password on CLI
```bash
sudo ./rpc amtinfo --sync --url https://<host-ip>:8181/api/v1/devices \
  --auth-endpoint https://<host-ip>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug -v
```
  
```bash
sudo ./rpc activate --local --profile <acm-profile-name>.yaml \
  --key "<profile-key>" \
  --skip-amt-cert-check -v \
  --auth-endpoint "https://<host-ip>:8181/api/v1/authorize" \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug
```
  
```bash
sudo ./rpc activate \
  --url "https://<host-ip>:8181/api/v1/admin/profiles/export/<acm-profile-name>?domainName=<domain-name>" \
  --auth-username <username> --auth-password "<password>" \
  --skip-amt-cert-check --skip-cert-check -v --log-level=debug
```
  
```bash
sudo ./rpc deactivate --local --skip-amt-cert-check -v \
  --auth-endpoint "https://<host-ip>:8181/api/v1/authorize" \
  --auth-username "<username>" \
  --auth-password "<password>" \
  --log-level=debug --skip-cert-check
```
  
# Commands that WON'T SHOW WARNING (Secure - credentials from environment)

Note: Use sudo -E to preserve environment variables!

No authentication needed - NO WARN
```bash
sudo ./rpc amtinfo
sudo ./rpc version
```

Basic auth from environment - NO WARN
```bash
AUTH_USERNAME=<username> AUTH_PASSWORD='<password>' ./rpc version
```

Token from environment - NO WARN
```bash
// Inline
AUTH_TOKEN=$AUTH_TOKEN ./rpc version

// # Or with exported variables
sudo -E ./rpc version
```

Full commands with environment auth

```bash
sudo -E ./rpc amtinfo --sync --url https://<host-ip>:8181/api/v1/devices \
  --auth-endpoint https://<host-ip>:8181/api/v1/authorize \
  --skip-cert-check --log-level=debug -v
```

```bash
sudo -E ./rpc activate --local --profile <acm-profile-name>.yaml \
  --key "<profile-key>" \
  --skip-amt-cert-check -v \
  --auth-endpoint "https://<host-ip>:8181/api/v1/authorize" \
  --skip-cert-check --log-level=debug
```
  
```bash
sudo -E ./rpc activate \
  --url "https://<host-ip>:8181/api/v1/admin/profiles/export/<acm-profile-name>?domainName=<domain-name>" \
  --skip-amt-cert-check --skip-cert-check -v --log-level=debug
```
  
```bash
sudo -E ./rpc deactivate --local --skip-amt-cert-check -v \
  --auth-endpoint "https://<host-ip>:8181/api/v1/authorize" \
  --log-level=debug --skip-cert-check
```

# Windows

Windows (Run as Administrator):

Powershell
```bash
$env:AUTH_TOKEN="eyJh...."
$env:AUTH_USERNAME=<username>
$env:AUTH_PASSWORD="<password>"
echo $env:AUTH_TOKEN
```

Command terminal
```bash
set AUTH_TOKEN="eyJh...."
set AUTH_USERNAME=<username>
set AUTH_PASSWORD="<password>"

echo %AUTH_TOKEN%
echo %AUTH_USERNAME%
echo %AUTH_PASSWORD%

rpc.exe  version --auth-token $AUTH_TOKEN
```

# Testing Note: 
Kong Configuration Precedence
When testing the warning message with environment variables, be aware of Kong's configuration precedence:

Kong reads values in this order:

CLI flags (highest priority)
Config file (config.yaml)
Environment variables
Defaults (lowest priority)

Important: If config.yaml contains empty string values like:
auth-username: ""
auth-password: ""
Kong will use these empty values and will not fall through to environment variables. This can make it appear that export AUTH_USERNAME=... is not working.

Solutions:

Option 1: Comment out or remove the empty fields from config.yaml:
```bash
# auth-username: ""  ← Comment out
# auth-password: ""  ← Comment out
```
Option 2: Pass credentials via CLI flags (for testing warnings):
sudo ./rpc activate --auth-username admin --auth-password secret ...
Option 3: Set values directly in config.yaml (but this triggers the security warning if the fields are used)
This does not affect the security warning itself - the warning correctly detects when credentials are passed via CLI flags regardless of the config file state.