### PR TITLE
build: bump Go base image to 1.26.6 to address critical stdlib vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # * SPDX-License-Identifier: Apache-2.0
 # **********************************************************************
 
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 RUN apk update && apk upgrade && apk add --no-cache git
 


### PR DESCRIPTION
Pin Dockerfile builder image digest to golang:1.26-alpine (1.26.6), fixing CVE-2026-39821 and CVE-2026-46600 in the Go stdlib.