### PR TITLE
fix(heci): support /dev/mei0-mei3 for RPC v3 connection

### DIFF
--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"sync"
 	"syscall"
@@ -39,8 +40,6 @@ type Driver struct {
 const (
 	Device                   = "/dev/mei0"
 	IOCTL_MEI_CONNECT_CLIENT = 0xC0104801
-	errMsgPermissionDenied   = "open /dev/mei0: permission denied"
-	errMsgNoSuchFile         = "open /dev/mei0: no such file or directory"
 	pollWarnLogInterval      = 15 * time.Second
 	// heciConnectAttempts bounds the MEI_CONNECT_CLIENT EBUSY retry loop.
 	// Connect almost always succeeds on retry 1 after a reopen; the extra
@@ -55,6 +54,11 @@ const (
 	// heciWriteBusyAttempts bounds the EBUSY retry loop around a HECI write.
 	heciWriteBusyAttempts = 3
 )
+
+// meiDevicePaths lists the MEI character devices probed in order. Mirrors the
+// LMS client, which tries /dev/mei0 through /dev/mei3 and uses the first device
+// that exposes the requested client GUID.
+var meiDevicePaths = []string{"/dev/mei0", "/dev/mei1", "/dev/mei2", "/dev/mei3"}
 
 // PTHI
 var MEI_IAMTHIF = [16]uint8{0x28, 0x00, 0xf8, 0x12, 0xb7, 0xb4, 0x2d, 0x4b, 0xac, 0xa8, 0x46, 0xe0, 0xff, 0x65, 0x81, 0x4c}
@@ -94,25 +98,26 @@ func (heci *Driver) Init(useLME, useWD bool) error {
 	return heci.initLocked(useLME, useWD)
 }
 
-// openMEIDevice closes any previously opened MEI handle and reopens the device,
-// logging a privilege/availability hint when the open fails. Shared by every
-// Init* entry point so the close-then-reopen and error-classification logic
-// lives in one place.
-func (heci *Driver) openMEIDevice() error {
+// openMEIDevicePath closes any previously opened MEI handle and opens the given
+// device node, classifying the failure for logging. Shared by the device-probe
+// loop so the close-then-reopen and error-classification logic lives in one
+// place. Failures are logged at debug because probing missing nodes is expected
+// while iterating /dev/mei0..3; the overall failure is surfaced by openAndConnect.
+func (heci *Driver) openMEIDevicePath(path string) error {
 	if heci.meiDevice != nil {
 		_ = heci.meiDevice.Close()
 		heci.meiDevice = nil
 	}
 
-	dev, err := os.OpenFile(Device, syscall.O_RDWR, 0)
+	dev, err := os.OpenFile(path, syscall.O_RDWR, 0)
 	if err != nil {
-		switch err.Error() {
-		case errMsgPermissionDenied:
-			log.Debug("need administrator privileges")
-		case errMsgNoSuchFile:
-			log.Error("AMT not found: MEI/driver is missing or the call to the HECI driver failed")
+		switch {
+		case errors.Is(err, fs.ErrPermission):
+			log.Debugf("need administrator privileges to open %s", path)
+		case errors.Is(err, fs.ErrNotExist):
+			log.Debugf("%s not present", path)
 		default:
-			log.Errorf("Cannot open MEI Device: %v", err)
+			log.Debugf("cannot open %s: %v", path, err)
 		}
 
 		return err
@@ -121,6 +126,80 @@ func (heci *Driver) openMEIDevice() error {
 	heci.meiDevice = dev
 
 	return nil
+}
+
+// connectClient issues MEI_CONNECT_CLIENT on the currently open device for the
+// GUID in data. It retries up to attempts times; when ramp is true the backoff
+// grows per attempt and only EBUSY is retried (the IAMTHIF/LME/WD path),
+// otherwise every failure is retried immediately (GUID-targeted clients).
+func (heci *Driver) connectClient(data *CMEIConnectClientData, attempts int, ramp bool) error {
+	var err error
+
+	for i := 0; i < attempts; i++ {
+		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(data)))
+		if err == nil {
+			return nil
+		}
+
+		if !ramp {
+			continue
+		}
+
+		// Only a busy device is worth retrying; any other error won't clear by
+		// waiting. Don't sleep after the final attempt - there's no retry left.
+		if !errors.Is(err, syscall.EBUSY) || i == attempts-1 {
+			break
+		}
+
+		// Per-attempt busy is an expected transient (the ME settles within a few
+		// retries); log at debug so it only shows under -v.
+		log.Debugf("mei connect busy, retry %d", i+1)
+		time.Sleep(time.Duration(i+1) * utils.HeciConnectRetryBackoff * time.Millisecond)
+	}
+
+	return err
+}
+
+// openAndConnect probes meiDevicePaths in order, mirroring the LMS client. For
+// each node it opens the device and attempts to connect the client GUID in
+// data. A node that is absent/inaccessible, or present but not hosting the
+// requested client, is skipped and the next node is tried. A busy device stops
+// the probe (like LMS breaking out on TEE_BUSY) because another node won't
+// clear it. On success the connected handle is left open on the driver.
+func (heci *Driver) openAndConnect(data *CMEIConnectClientData, attempts int, ramp bool) error {
+	var lastErr error
+
+	for _, path := range meiDevicePaths {
+		if err := heci.openMEIDevicePath(path); err != nil {
+			lastErr = err
+
+			continue
+		}
+
+		if err := heci.connectClient(data, attempts, ramp); err != nil {
+			lastErr = err
+
+			if errors.Is(err, syscall.EBUSY) {
+				break
+			}
+
+			continue
+		}
+
+		return nil
+	}
+
+	// No device connected; drop any dangling handle from the last probe.
+	if heci.meiDevice != nil {
+		_ = heci.meiDevice.Close()
+		heci.meiDevice = nil
+	}
+
+	if lastErr != nil && errors.Is(lastErr, fs.ErrNotExist) {
+		log.Error("AMT not found: MEI/driver is missing or the call to the HECI driver failed")
+	}
+
+	return lastErr
 }
 
 // parseConnectClientData reads the MEI_CONNECT_CLIENT response out of data and
@@ -145,11 +224,6 @@ func (heci *Driver) initLocked(useLME, useWD bool) error {
 	heci.useWD = useWD
 	heci.useGUIDClient = false
 
-	// Close any previous device handle before reopening.
-	if err := heci.openMEIDevice(); err != nil {
-		return err
-	}
-
 	data := CMEIConnectClientData{}
 	if useWD {
 		data.data = MEI_WDIF
@@ -159,32 +233,12 @@ func (heci *Driver) initLocked(useLME, useWD bool) error {
 		data.data = MEI_IAMTHIF
 	}
 
-	var err error
-
-	// retry with backoff in case the device is busy after a reset. The ME is
-	// typically ready within a few ms of a reopen and connect succeeds on the
-	// first retry, so start with a short backoff and ramp up only for the
-	// rarer cases where it stays busy longer. Don't sleep after the final
-	// attempt - there's no retry left to wait for.
-	for i := 0; i < heciConnectAttempts; i++ {
-		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(&data)))
-		if err == nil {
-			break
-		}
-
-		// Only a busy device is worth retrying; any other error won't clear by
-		// waiting. Don't sleep after the final attempt - there's no retry left.
-		if !errors.Is(err, syscall.EBUSY) || i == heciConnectAttempts-1 {
-			break
-		}
-
-		// Per-attempt busy is an expected transient (the ME settles within a few
-		// retries); log at debug so it only shows under -v. The exhausted-ladder
-		// case below emits a single warning.
-		log.Debugf("mei connect busy, retry %d", i+1)
-		time.Sleep(time.Duration(i+1) * utils.HeciConnectRetryBackoff * time.Millisecond)
-	}
-
+	// Probe /dev/mei0..3 (LMS-style) and connect the client on the first device
+	// that hosts it. EBUSY is retried per device with a ramped backoff: the ME
+	// is typically ready within a few ms of a reopen and connect succeeds on the
+	// first retry, so the backoff starts short and ramps up only for the rarer
+	// cases where the device stays busy longer.
+	err := heci.openAndConnect(&data, heciConnectAttempts, true)
 	if err != nil {
 		if errors.Is(err, syscall.EBUSY) {
 			log.Warnf("mei connect still busy after %d attempts", heciConnectAttempts)
@@ -211,24 +265,11 @@ func (heci *Driver) InitWithGUID(guid interface{}) error {
 		return errors.New("invalid GUID type for Linux, expected [16]uint8")
 	}
 
-	// Close any previous device handle before reopening.
-	if err := heci.openMEIDevice(); err != nil {
-		return err
-	}
-
 	data := CMEIConnectClientData{}
 	data.data = guidBytes
 
-	var err error
-
-	for i := 0; i < guidConnectAttempts; i++ {
-		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(&data)))
-		if err == nil {
-			break
-		}
-	}
-
-	if err != nil {
+	// Probe /dev/mei0..3 (LMS-style) for the device hosting this client GUID.
+	if err := heci.openAndConnect(&data, guidConnectAttempts, false); err != nil {
 		return err
 	}
 
@@ -244,26 +285,11 @@ func (heci *Driver) InitHOTHAM() error {
 	heci.useWD = false
 	heci.useGUIDClient = true
 
-	// Close any previous device handle before reopening.
-	if err := heci.openMEIDevice(); err != nil {
-		return err
-	}
-
 	data := CMEIConnectClientData{}
 	data.data = MEI_HOTHAM
 
-	var err error
-
-	for i := 0; i < guidConnectAttempts; i++ {
-		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(&data)))
-		if err == nil {
-			log.Tracef("InitHOTHAM: Connected successfully on attempt %d", i+1)
-
-			break
-		}
-	}
-
-	if err != nil {
+	// Probe /dev/mei0..3 (LMS-style) for the device hosting the HOTHAM client.
+	if err := heci.openAndConnect(&data, guidConnectAttempts, false); err != nil {
 		log.Errorf("InitHOTHAM: Failed to connect to HOTHAM GUID after %d attempts: %v", guidConnectAttempts, err)
 
 		return err

--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -167,11 +167,21 @@ func (heci *Driver) connectClient(data *CMEIConnectClientData, attempts int, ram
 // the probe (like LMS breaking out on TEE_BUSY) because another node won't
 // clear it. On success the connected handle is left open on the driver.
 func (heci *Driver) openAndConnect(data *CMEIConnectClientData, attempts int, ramp bool) error {
-	var lastErr error
+	var (
+		lastErr error
+		permErr error
+	)
 
 	for _, path := range meiDevicePaths {
 		if err := heci.openMEIDevicePath(path); err != nil {
-			lastErr = err
+			if errors.Is(err, fs.ErrPermission) && permErr == nil {
+				permErr = err
+			}
+			// Avoid masking earlier errors (eg permission denied) with a later
+			// fs.ErrNotExist from trailing probe paths.
+			if lastErr == nil || errors.Is(lastErr, fs.ErrNotExist) {
+				lastErr = err
+			}
 
 			continue
 		}

--- a/pkg/heci/linux_test.go
+++ b/pkg/heci/linux_test.go
@@ -9,9 +9,13 @@ package heci
 import (
 	"bytes"
 	"encoding/binary"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Version struct {
@@ -129,4 +133,115 @@ func TestReceiveMessage(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Positive(t, bytesRead)
+}
+
+// TestMeiDevicePathsOrder pins the LMS-style probe order: /dev/mei0..3 ascending.
+func TestMeiDevicePathsOrder(t *testing.T) {
+	expected := []string{"/dev/mei0", "/dev/mei1", "/dev/mei2", "/dev/mei3"}
+	assert.Equal(t, expected, meiDevicePaths)
+}
+
+// TestOpenMEIDevicePathNotExist verifies opening a missing node fails and leaves
+// no handle on the driver.
+func TestOpenMEIDevicePathNotExist(t *testing.T) {
+	h := Driver{}
+	err := h.openMEIDevicePath(filepath.Join(t.TempDir(), "mei0"))
+
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.Nil(t, h.meiDevice)
+}
+
+// TestOpenAndConnectNoDevices verifies that when no MEI node exists the probe
+// reports a not-found error and leaves no dangling handle on the driver.
+func TestOpenAndConnectNoDevices(t *testing.T) {
+	orig := meiDevicePaths
+	defer func() { meiDevicePaths = orig }()
+
+	dir := t.TempDir()
+	meiDevicePaths = []string{
+		filepath.Join(dir, "mei0"),
+		filepath.Join(dir, "mei1"),
+	}
+
+	h := Driver{}
+	data := CMEIConnectClientData{data: MEI_IAMTHIF}
+	err := h.openAndConnect(&data, heciConnectAttempts, true)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.Nil(t, h.meiDevice)
+}
+
+// TestOpenAndConnectSkipsNonClientDevice verifies that a node which opens but is
+// not a real MEI client (the connect ioctl fails) is closed and skipped rather
+// than left open.
+func TestOpenAndConnectSkipsNonClientDevice(t *testing.T) {
+	orig := meiDevicePaths
+	defer func() { meiDevicePaths = orig }()
+
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "mei0")
+	require.NoError(t, os.WriteFile(fake, []byte{}, 0o600))
+	meiDevicePaths = []string{fake}
+
+	h := Driver{}
+	data := CMEIConnectClientData{data: MEI_IAMTHIF}
+	err := h.openAndConnect(&data, guidConnectAttempts, false)
+
+	assert.Error(t, err)
+	assert.Nil(t, h.meiDevice)
+}
+
+// TestOpenAndConnectAdvancesPastMissingDevice verifies the probe moves on from a
+// missing node to the next candidate instead of stopping at the first gap.
+func TestOpenAndConnectAdvancesPastMissingDevice(t *testing.T) {
+	orig := meiDevicePaths
+	defer func() { meiDevicePaths = orig }()
+
+	dir := t.TempDir()
+	present := filepath.Join(dir, "mei1")
+	require.NoError(t, os.WriteFile(present, []byte{}, 0o600))
+
+	// First node is absent; second exists but is not a real MEI client.
+	meiDevicePaths = []string{filepath.Join(dir, "mei0"), present}
+
+	h := Driver{}
+	data := CMEIConnectClientData{data: MEI_IAMTHIF}
+	err := h.openAndConnect(&data, guidConnectAttempts, false)
+
+	// Reached the second node (open ok, ioctl failed), so the error is the
+	// ioctl failure, not NotExist - proving it advanced past the missing node.
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, fs.ErrNotExist)
+	assert.Nil(t, h.meiDevice)
+}
+
+// TestInitNoDevices verifies Init surfaces an error (and no handle) when the
+// probe finds no usable MEI device.
+func TestInitNoDevices(t *testing.T) {
+	orig := meiDevicePaths
+	defer func() { meiDevicePaths = orig }()
+
+	meiDevicePaths = []string{filepath.Join(t.TempDir(), "missing")}
+
+	h := Driver{}
+	err := h.Init(false, false)
+
+	assert.Error(t, err)
+	assert.Nil(t, h.meiDevice)
+}
+
+// TestInitWithGUIDNoDevices verifies the GUID-targeted probe also fails cleanly
+// when no device is present.
+func TestInitWithGUIDNoDevices(t *testing.T) {
+	orig := meiDevicePaths
+	defer func() { meiDevicePaths = orig }()
+
+	meiDevicePaths = []string{filepath.Join(t.TempDir(), "missing")}
+
+	h := Driver{}
+	err := h.InitWithGUID(MEI_IAMTHIF)
+
+	assert.Error(t, err)
+	assert.Nil(t, h.meiDevice)
 }


### PR DESCRIPTION
Problem:
RPC command fail intermittently with Mei driver is not installed
<img width="1255" height="75" alt="image" src="https://github.com/user-attachments/assets/e1f639b8-20fc-4140-beb8-6fbdc69913ed" />

Fix:
linux.go was updated so the Linux HECI driver no longer assumes the ME interface is fixed at /dev/mei0: it now probes /dev/mei0 through /dev/mei3 in order and connects to the first node that hosts the requested ME client (AMT/PTHI, LME, watchdog, or HOTHAM), skipping absent or non-matching nodes and stopping only on a busy device — matching LMS behavior and fixing the failure to connect when the device is at a non-zero index. Supporting changes replace the hardcoded /dev/mei0 error-string checks with device-agnostic filesystem error classification, and consolidate the three init entry points through the shared probe routine (preserving the existing busy-device retry/back-off), so the reconnect path benefits too; Windows is unaffected since it doesn't use /dev/meiN paths.

Test:
<img width="1476" height="570" alt="image" src="https://github.com/user-attachments/assets/83738e47-7df1-4bdc-9f24-4611455f2812" />

30 Cycle of reboot then run rpc amtinfo below are the result for binary and docker:
Binary:
<img width="435" height="869" alt="image" src="https://github.com/user-attachments/assets/e063eb70-00ac-4899-8889-8180cec59d6c" />

Docker:
<img width="362" height="898" alt="image" src="https://github.com/user-attachments/assets/a95e8c8a-3c07-477a-8123-abc74f6b9d27" />
