### PR TITLE
refactor: remove duplicate branches in AMTCommand.Initialize

### DIFF
--- a/internal/amt/commands.go
+++ b/internal/amt/commands.go
@@ -155,11 +155,7 @@ func (amt AMTCommand) Initialize() error {
 	// initialize HECI interface
 	err := amt.PTHI.Open(false)
 	if err != nil {
-		if err.Error() == "The handle is invalid." {
-			return utils.HECIDriverNotDetected //, errors.New("AMT not found: MEI/driver is missing or the call to the HECI driver failed")
-		} else {
-			return utils.HECIDriverNotDetected //, errors.New("unable to initialize")
-		}
+		return utils.HECIDriverNotDetected
 	}
 
 	defer amt.PTHI.Close()


### PR DESCRIPTION
Both arms of the inner conditional returned utils.HECIDriverNotDetected, so the check on the error string computed a result that was discarded. The distinct errors it once selected between were commented out in 73ca5410 when Initialize dropped its bool return value.

Collapse to a single error check. Behavior is unchanged; the existing mock drives both paths and its tests still pass.