### PR TITLE
fix: Update to use the /dev/mei symlink instead of hardcode to mei0

### DIFF
--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -25,7 +25,7 @@ type Driver struct {
 }
 
 const (
-	Device                   = "/dev/mei0"
+	Device                   = "/dev/mei"
 	IOCTL_MEI_CONNECT_CLIENT = 0xC0104801
 )
 
@@ -47,9 +47,9 @@ func (heci *Driver) Init(useLME, useWD bool) error {
 
 	heci.meiDevice, err = os.OpenFile(Device, syscall.O_RDWR, 0)
 	if err != nil {
-		if err.Error() == "open /dev/mei0: permission denied" {
+		if os.IsPermission(err) {
 			log.Error("need administrator privileges")
-		} else if err.Error() == "open /dev/mei0: no such file or directory" {
+		} else if os.IsNotExist(err) {
 			log.Error("AMT not found: MEI/driver is missing or the call to the HECI driver failed")
 		} else {
 			log.Error("Cannot open MEI Device")

--- a/pkg/heci/linux_test.go
+++ b/pkg/heci/linux_test.go
@@ -10,6 +10,9 @@ package heci
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +34,34 @@ type MessageHeader struct {
 }
 type GetUUIDRequest struct {
 	Header MessageHeader
+}
+
+func TestDeviceUsesMeiSymlink(t *testing.T) {
+	assert.Equal(t, "/dev/mei", Device)
+}
+
+// Guards the Init() error classification, which relies on os.IsNotExist /
+// os.IsPermission rather than matching err.Error() strings.
+func TestOpenFileErrorsAreClassified(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := os.OpenFile(missing, syscall.O_RDWR, 0)
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "missing device should be classified as not-exist")
+	assert.False(t, os.IsPermission(err))
+
+	denied := filepath.Join(t.TempDir(), "no-perms")
+	f, err := os.OpenFile(denied, os.O_CREATE|os.O_WRONLY, 0)
+	assert.NoError(t, err)
+	f.Close()
+
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permission checks")
+	}
+
+	_, err = os.OpenFile(denied, syscall.O_RDWR, 0)
+	assert.Error(t, err)
+	assert.True(t, os.IsPermission(err), "unreadable file should be classified as permission error")
+	assert.False(t, os.IsNotExist(err))
 }
 
 func TestHeciInit(t *testing.T) {


### PR DESCRIPTION
**Problem**
The 0 is an enumeration index assigned by the kernel MEI driver in probe order. On platforms with more than one MEI/HECI interface (e.g. discrete graphics with its own ME, or multiple management engines), the AMT/management interface is not guaranteed to enumerate as index 0 — it could be /dev/mei1, /dev/mei2, etc. Hardcoding mei0 opens the wrong device (or a non-existent one) on those systems.
<img width="1241" height="76" alt="image" src="https://github.com/user-attachments/assets/775a21d0-6867-44da-a956-08e6d67104a8" />


**Fix**
The kernel MEI driver, together with udev, creates a stable symlink /dev/mei that points to the primary/default MEI device node. It resolves to the correct underlying /dev/meiN regardless of the enumeration index. So opening /dev/mei:

- Works on single-interface systems (points to mei0).

- Works on multi-interface systems (points to whichever node is the primary management interface).

- Decouples the code from kernel probe ordering, which can vary across boots, kernel versions, and hardware.

**Test**
<img width="534" height="497" alt="image" src="https://github.com/user-attachments/assets/78bd3622-cdf0-437d-bdfe-6e6af9c0dbd7" />
