### PR TITLE
fix: Update to use the /dev/mei symlink instead of hardcode to mei0

### DIFF
--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -37,10 +37,10 @@ type Driver struct {
 }
 
 const (
-	Device                   = "/dev/mei0"
+	Device                   = "/dev/mei"
 	IOCTL_MEI_CONNECT_CLIENT = 0xC0104801
-	errMsgPermissionDenied   = "open /dev/mei0: permission denied"
-	errMsgNoSuchFile         = "open /dev/mei0: no such file or directory"
+	errMsgPermissionDenied   = "open /dev/mei: permission denied"
+	errMsgNoSuchFile         = "open /dev/mei: no such file or directory"
 	pollWarnLogInterval      = 15 * time.Second
 	// heciConnectAttempts bounds the MEI_CONNECT_CLIENT EBUSY retry loop.
 	// Connect almost always succeeds on retry 1 after a reopen; the extra

--- a/pkg/heci/linux_test.go
+++ b/pkg/heci/linux_test.go
@@ -32,6 +32,12 @@ type GetUUIDRequest struct {
 	Header MessageHeader
 }
 
+func TestDeviceUsesMeiSymlink(t *testing.T) {
+	assert.Equal(t, "/dev/mei", Device)
+	assert.Equal(t, "open /dev/mei: permission denied", errMsgPermissionDenied)
+	assert.Equal(t, "open /dev/mei: no such file or directory", errMsgNoSuchFile)
+}
+
 func TestHeciInit(t *testing.T) {
 	h := Driver{}
 	err := h.Init(false, false)


### PR DESCRIPTION
**Problem**
The 0 is an enumeration index assigned by the kernel MEI driver in probe order. On platforms with more than one MEI/HECI interface (e.g. discrete graphics with its own ME, or multiple management engines), the AMT/management interface is not guaranteed to enumerate as index 0 — it could be /dev/mei1, /dev/mei2, etc. Hardcoding mei0 opens the wrong device (or a non-existent one) on those systems.
https://jira.devtools.intel.com/browse/CM-318
<img width="1252" height="82" alt="image" src="https://github.com/user-attachments/assets/752cadc4-a781-42dd-84a1-47291d1f12c7" />

**Fix**
The kernel MEI driver, together with udev, creates a stable symlink /dev/mei that points to the primary/default MEI device node. It resolves to the correct underlying /dev/meiN regardless of the enumeration index. So opening /dev/mei:

- Works on single-interface systems (points to mei0).

- Works on multi-interface systems (points to whichever node is the primary management interface).

- Decouples the code from kernel probe ordering, which can vary across boots, kernel versions, and hardware.

**Test**
<img width="737" height="813" alt="image" src="https://github.com/user-attachments/assets/494e16ab-55bd-4862-8712-6042814301e1" />


