### PR TITLE
feat: send additional device export fields as required for device export

### DIFF
--- a/internal/commands/activate/activate.go
+++ b/internal/commands/activate/activate.go
@@ -840,14 +840,20 @@ func (cmd *ActivateCmd) postActivationSync(ctx *commands.Context, consoleBaseURL
 
 	endpoint := commands.BuildDevicesEndpoint(ctx.DevicesEndpoint, consoleBaseURL)
 
-	// Sync deviceInfo fields (FW version, OS info, discovery data)
-	if err := commands.SyncDeviceInfoHelper(ctx, &cmd.AMTBaseCmd, endpoint, token, guid); err != nil {
-		log.Warnf("Post-activation deviceInfo sync failed: %v", err)
-	}
-
 	// Update TLS connection settings which may have changed during activation
 	if err := cmd.updateTLSSettingsAfterActivation(ctx, consoleBaseURL, token, guid); err != nil {
 		log.Warnf("Post-activation TLS settings update failed: %v", err)
+	}
+
+	// Reuse the WSMAN client regardless of whether the Console TLS update above
+	// succeeded: EnsureWSMAN may have established a usable connection even if the
+	// subsequent Console PATCH failed, and that connection is still valid for
+	// collecting TLS/802.1x discovery fields below.
+	syncWSMAN := cmd.GetWSManClient()
+
+	// Sync deviceInfo fields (FW version, OS info, discovery data)
+	if err := commands.SyncDeviceInfoHelper(ctx, &cmd.AMTBaseCmd, syncWSMAN, endpoint, token, guid); err != nil {
+		log.Warnf("Post-activation deviceInfo sync failed: %v", err)
 	}
 }
 

--- a/internal/commands/activate/activate_test.go
+++ b/internal/commands/activate/activate_test.go
@@ -1029,6 +1029,8 @@ func TestPostActivationSync_SendsPatch(t *testing.T) {
 	mockAMT.EXPECT().GetControlMode().Return(2, nil).AnyTimes()
 	mockAMT.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55", IPAddress: "10.49.76.154"}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE", IPAddress: "0.0.0.0"}, nil)
+	mockAMT.EXPECT().GetDNSSuffix().Return("amt.example.com", nil)
+	mockAMT.EXPECT().GetOSDNSSuffix().Return("example.com", nil)
 
 	deviceInfoPatchCalled := 0
 
@@ -1103,6 +1105,8 @@ func TestRunLocalActivation_Failure_StillAttemptsPostActivationSync(t *testing.T
 	mockAMT.EXPECT().GetControlMode().Return(1, nil).AnyTimes()
 	mockAMT.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55", IPAddress: "10.49.76.154"}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE", IPAddress: "0.0.0.0"}, nil)
+	mockAMT.EXPECT().GetDNSSuffix().Return("amt.example.com", nil)
+	mockAMT.EXPECT().GetOSDNSSuffix().Return("example.com", nil)
 
 	patchCalled := 0
 

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -444,37 +444,54 @@ type syncPayload struct {
 }
 
 type syncDeviceInfo struct {
-	FWVersion            string        `json:"fwVersion"`
-	FWBuild              string        `json:"fwBuild"`
-	FWSku                string        `json:"fwSku"`
-	Discovered           *bool         `json:"discovered,omitempty"`
-	FirstDiscovered      *time.Time    `json:"firstDiscovered,omitempty"`
-	CurrentMode          string        `json:"currentMode"`
-	Features             string        `json:"features"`
-	IPAddress            string        `json:"ipAddress"`
-	LastSynced           *time.Time    `json:"lastSynced,omitempty"`
-	TLSMode              string        `json:"tlsMode,omitempty"`
-	UPID                 *syncUPIDInfo `json:"upid,omitempty"`
-	AMTEnabledInBIOS     *bool         `json:"amtEnabledInBIOS,omitempty"`
-	MEInterfaceVersion   string        `json:"meInterfaceVersion,omitempty"`
-	DHCPEnabled          *bool         `json:"dhcpEnabled,omitempty"`
-	CertHashes           []string      `json:"certHashes,omitempty"`
-	LMSInstalled         bool          `json:"lmsInstalled"`
-	LMSVersion           string        `json:"lmsVersion,omitempty"`
-	OSName               string        `json:"osName"`
-	OSVersion            string        `json:"osVersion,omitempty"`
-	OSDistro             string        `json:"osDistro,omitempty"`
-	CPUModel             string        `json:"cpuModel,omitempty"`
-	OSIPAddress          string        `json:"osIpAddress,omitempty"`
-	EthernetAdapterCount int           `json:"ethernetAdapterCount,omitempty"`
-	MonitorConnected     *bool         `json:"monitorConnected,omitempty"`
-	IEEE8021xEnabled     *bool         `json:"ieee8021xEnabled,omitempty"`
+	FWVersion            string                   `json:"fwVersion"`
+	FWBuild              string                   `json:"fwBuild"`
+	FWSku                string                   `json:"fwSku"`
+	Discovered           *bool                    `json:"discovered,omitempty"`
+	FirstDiscovered      *time.Time               `json:"firstDiscovered,omitempty"`
+	CurrentMode          string                   `json:"currentMode"`
+	Features             string                   `json:"features"`
+	IPAddress            string                   `json:"ipAddress"`
+	LastSynced           *time.Time               `json:"lastSynced,omitempty"`
+	TLSMode              string                   `json:"tlsMode,omitempty"`
+	UPID                 *syncUPIDInfo            `json:"upid,omitempty"`
+	AMTEnabledInBIOS     *bool                    `json:"amtEnabledInBIOS,omitempty"`
+	MEInterfaceVersion   string                   `json:"meInterfaceVersion,omitempty"`
+	DHCPEnabled          *bool                    `json:"dhcpEnabled,omitempty"`
+	CertHashes           []string                 `json:"certHashes,omitempty"`
+	LMSInstalled         bool                     `json:"lmsInstalled"`
+	LMSVersion           string                   `json:"lmsVersion,omitempty"`
+	OSName               string                   `json:"osName"`
+	OSVersion            string                   `json:"osVersion,omitempty"`
+	OSDistro             string                   `json:"osDistro,omitempty"`
+	OSDNSSuffix          string                   `json:"dnsSuffixOS,omitempty"`
+	CPUModel             string                   `json:"cpuModel,omitempty"`
+	OSIPAddress          string                   `json:"osIpAddress,omitempty"`
+	EthernetAdapterCount int                      `json:"ethernetAdapterCount,omitempty"`
+	MonitorConnected     *bool                    `json:"monitorConnected,omitempty"`
+	IEEE8021xEnabled     *bool                    `json:"ieee8021xEnabled,omitempty"`
+	MENetwork            *syncMENetwork           `json:"meNetwork,omitempty"`
+	OSNetwork            *utils.OSNetworkAdapters `json:"osNetwork,omitempty"`
+	PlatformAdapters     *utils.PlatformAdapters  `json:"platformAdapters,omitempty"`
 }
 
 type syncUPIDInfo struct {
 	CSMEId            string `json:"csmeId,omitempty"`
 	OEMId             string `json:"oemId,omitempty"`
 	OEMPlatformIdType string `json:"oemPlatformIdType,omitempty"`
+}
+
+type syncMENetwork struct {
+	Wired    *syncMEInterface `json:"wired,omitempty"`
+	Wireless *syncMEInterface `json:"wireless,omitempty"`
+}
+
+type syncMEInterface struct {
+	IPAddress   string `json:"ipAddress,omitempty"`
+	DHCPEnabled *bool  `json:"dhcpEnabled,omitempty"`
+	DHCPMode    string `json:"dhcpMode,omitempty"`
+	LinkStatus  string `json:"linkStatus,omitempty"`
+	MACAddress  string `json:"macAddress,omitempty"`
 }
 
 // SyncDeviceInfo sends a PATCH to the provided endpoint URL with the device info payload.
@@ -817,7 +834,7 @@ func BuildDevicesEndpoint(devicesEndpoint, consoleBaseURL string) string {
 }
 
 // SyncDeviceInfoHelper is a shared helper for post-lifecycle device sync
-func SyncDeviceInfoHelper(ctx *Context, baseCmd *AMTBaseCmd, endpoint, token, guid string) error {
+func SyncDeviceInfoHelper(ctx *Context, baseCmd *AMTBaseCmd, wsman interfaces.WSMANer, endpoint, token, guid string) error {
 	log.Debug("Starting device info collection for sync")
 
 	infoCmd := &AmtInfoCmd{
@@ -828,6 +845,7 @@ func SyncDeviceInfoHelper(ctx *Context, baseCmd *AMTBaseCmd, endpoint, token, gu
 		UUID:       true,
 		Mode:       true,
 		Lan:        true,
+		DNS:        true,
 	}
 
 	log.Debug("Initializing info service for sync")
@@ -837,6 +855,7 @@ func SyncDeviceInfoHelper(ctx *Context, baseCmd *AMTBaseCmd, endpoint, token, gu
 		WithLocalTLSEnforced(baseCmd.LocalTLSEnforced),
 		WithSkipAMTCertCheck(ctx.SkipAMTCertCheck),
 		WithHECIAvailable(baseCmd.HECIAvailable),
+		WithWSMANClient(wsman),
 	)
 
 	log.Debug("Collecting AMT device information")
@@ -899,6 +918,8 @@ func (s *InfoService) populateDiscoveryFields(info *syncDeviceInfo, result *Info
 	if result.WiredAdapter != nil {
 		info.DHCPEnabled = &result.WiredAdapter.DHCPEnabled
 	}
+
+	info.MENetwork = buildSyncMENetwork(result)
 
 	// Certificate hashes (extract hash strings)
 	if result.CertificateHashes != nil {
@@ -971,10 +992,21 @@ func (s *InfoService) populateDiscoveryFields(info *syncDeviceInfo, result *Info
 
 	info.OSVersion = osInfo.Version
 	info.OSDistro = osInfo.Distro
+	info.OSDNSSuffix = result.DNSSuffixOS
 	info.CPUModel = utils.GetCPUModel()
 	info.OSIPAddress = utils.GetOSIPAddress()
 	info.EthernetAdapterCount = utils.GetEthernetAdapterCount()
 	info.MonitorConnected = utils.DetectMonitorConnected()
+
+	osNetwork := utils.GetOSNetworkAdapters()
+	if len(osNetwork.Wired) > 0 || osNetwork.Wireless != nil {
+		info.OSNetwork = &osNetwork
+	}
+
+	platformAdapters := utils.GetPlatformAdapters()
+	if platformAdapters.Wired != "" || platformAdapters.Wireless != "" {
+		info.PlatformAdapters = &platformAdapters
+	}
 
 	monitorConnected := statusUnknown
 	if info.MonitorConnected != nil {
@@ -990,6 +1022,39 @@ func (s *InfoService) populateDiscoveryFields(info *syncDeviceInfo, result *Info
 		info.EthernetAdapterCount,
 		monitorConnected,
 	)
+}
+
+func buildSyncMENetwork(result *InfoResult) *syncMENetwork {
+	network := &syncMENetwork{}
+	if result.WiredAdapter != nil {
+		network.Wired = buildSyncMEInterface(result.WiredAdapter)
+	}
+
+	if result.WirelessAdapter != nil {
+		network.Wireless = buildSyncMEInterface(result.WirelessAdapter)
+	}
+
+	if network.Wired == nil && network.Wireless == nil {
+		return nil
+	}
+
+	return network
+}
+
+func buildSyncMEInterface(adapter *amt.InterfaceSettings) *syncMEInterface {
+	if adapter == nil {
+		return nil
+	}
+
+	dhcpEnabled := adapter.DHCPEnabled
+
+	return &syncMEInterface{
+		IPAddress:   strings.TrimSpace(adapter.IPAddress),
+		DHCPEnabled: &dhcpEnabled,
+		DHCPMode:    strings.TrimSpace(adapter.DHCPMode),
+		LinkStatus:  strings.TrimSpace(adapter.LinkStatus),
+		MACAddress:  strings.TrimSpace(adapter.MACAddress),
+	}
 }
 
 // getTLSModeFromWSMAN queries AMT TLS settings via WSMan and returns the mode string.

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -920,6 +920,7 @@ func (s *InfoService) populateDiscoveryFields(info *syncDeviceInfo, result *Info
 	}
 
 	info.MENetwork = buildSyncMENetwork(result)
+	log.Debugf("Collected ME network information: %+v", info.MENetwork)
 
 	// Certificate hashes (extract hash strings)
 	if result.CertificateHashes != nil {
@@ -1003,10 +1004,14 @@ func (s *InfoService) populateDiscoveryFields(info *syncDeviceInfo, result *Info
 		info.OSNetwork = &osNetwork
 	}
 
+	log.Debugf("Collected OS network information: %+v", info.OSNetwork)
+
 	platformAdapters := utils.GetPlatformAdapters()
-	if platformAdapters.Wired != "" || platformAdapters.Wireless != "" {
+	if len(platformAdapters.Wired) > 0 || len(platformAdapters.Wireless) > 0 {
 		info.PlatformAdapters = &platformAdapters
 	}
+
+	log.Debugf("Collected platform adapter information: %+v", info.PlatformAdapters)
 
 	monitorConnected := statusUnknown
 	if info.MonitorConnected != nil {

--- a/internal/commands/amtinfo_test.go
+++ b/internal/commands/amtinfo_test.go
@@ -211,6 +211,43 @@ func TestInfoService_populateDiscoveryFields_MEInterfaceVersion(t *testing.T) {
 	assert.Equal(t, expectedMEIVersion, info.MEInterfaceVersion)
 }
 
+func TestBuildSyncMENetwork(t *testing.T) {
+	result := &InfoResult{
+		WiredAdapter: &amt.InterfaceSettings{
+			IPAddress:   " 10.0.0.12 ",
+			DHCPEnabled: true,
+			DHCPMode:    " active ",
+			LinkStatus:  " up ",
+			MACAddress:  " AA:BB:CC:DD:EE:10 ",
+		},
+		WirelessAdapter: &amt.InterfaceSettings{
+			IPAddress:   "192.168.1.20",
+			DHCPEnabled: false,
+			DHCPMode:    "passive",
+			LinkStatus:  "down",
+			MACAddress:  "AA:BB:CC:DD:EE:20",
+		},
+	}
+
+	network := buildSyncMENetwork(result)
+
+	require.NotNil(t, network)
+	require.NotNil(t, network.Wired)
+	require.Equal(t, "10.0.0.12", network.Wired.IPAddress)
+	require.NotNil(t, network.Wired.DHCPEnabled)
+	require.True(t, *network.Wired.DHCPEnabled)
+	require.Equal(t, "active", network.Wired.DHCPMode)
+	require.Equal(t, "up", network.Wired.LinkStatus)
+	require.Equal(t, "AA:BB:CC:DD:EE:10", network.Wired.MACAddress)
+	require.NotNil(t, network.Wireless)
+	require.Equal(t, "192.168.1.20", network.Wireless.IPAddress)
+	require.NotNil(t, network.Wireless.DHCPEnabled)
+	require.False(t, *network.Wireless.DHCPEnabled)
+	require.Equal(t, "passive", network.Wireless.DHCPMode)
+	require.Equal(t, "down", network.Wireless.LinkStatus)
+	require.Equal(t, "AA:BB:CC:DD:EE:20", network.Wireless.MACAddress)
+}
+
 func TestAmtInfoCmd_Run_WithSync_BearerAuth(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -257,7 +257,7 @@ func (cmd *DeactivateCmd) postDeactivationSync(ctx *Context, consoleBaseURL, tok
 
 	endpoint := BuildDevicesEndpoint(ctx.DevicesEndpoint, consoleBaseURL)
 
-	if err := SyncDeviceInfoHelper(ctx, &cmd.AMTBaseCmd, endpoint, token, guid); err != nil {
+	if err := SyncDeviceInfoHelper(ctx, &cmd.AMTBaseCmd, nil, endpoint, token, guid); err != nil {
 		log.Warnf("Post-deactivation sync failed: %v", err)
 	}
 }

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -722,6 +722,7 @@ func TestExecuteHttpConsoleDeactivate_PostDeactivationSync(t *testing.T) {
 
 	mockAMT := mock.NewMockInterface(ctrl)
 	mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
+	mockAMT.EXPECT().GetOSDNSSuffix().Return("example.com", nil)
 
 	mockWSMAN := mock.NewMockWSMANer(ctrl)
 
@@ -774,6 +775,7 @@ func TestExecuteHttpConsoleDeactivate_CustomDevicesEndpoint(t *testing.T) {
 
 	mockAMT := mock.NewMockInterface(ctrl)
 	mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
+	mockAMT.EXPECT().GetOSDNSSuffix().Return("example.com", nil)
 
 	mockWSMAN := mock.NewMockWSMANer(ctrl)
 

--- a/pkg/amt/linux.go
+++ b/pkg/amt/linux.go
@@ -11,22 +11,54 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 )
 
 func (amt AMTCommand) GetOSDNSSuffix() (string, error) {
 	fqdn, err := getFQDN()
+	if err == nil {
+		if suffix := dnsSuffixFromFQDN(fqdn); suffix != "" {
+			return suffix, nil
+		}
+	}
+
+	if suffix := getNetworkManagerDNSSuffix(); suffix != "" {
+		return suffix, nil
+	}
+
+	return "", err
+}
+
+func dnsSuffixFromFQDN(fqdn string) string {
+	_, suffix, found := strings.Cut(strings.TrimSuffix(strings.TrimSpace(fqdn), "."), ".")
+	if !found {
+		return ""
+	}
+
+	return suffix
+}
+
+func getNetworkManagerDNSSuffix() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "nmcli", "-g", "IP4.DOMAIN,IP4.SEARCHES", "device", "show").Output()
 	if err != nil {
-		return "", err
+		return ""
 	}
 
-	splitName := strings.SplitAfterN(fqdn, ".", 2)
-	if len(splitName) == 2 {
-		return splitName[1], nil
+	for line := range strings.Lines(string(out)) {
+		for _, part := range strings.Split(line, ",") {
+			suffix := strings.TrimSpace(part)
+			if suffix != "" && suffix != "--" {
+				return suffix
+			}
+		}
 	}
 
-	return fqdn, err
+	return ""
 }
 
 func getFQDN() (string, error) {

--- a/pkg/amt/linux_test.go
+++ b/pkg/amt/linux_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package amt
+
+import "testing"
+
+func TestDNSSuffixFromFQDN(t *testing.T) {
+	tests := []struct {
+		name string
+		fqdn string
+		want string
+	}{
+		{name: "fully qualified", fqdn: "host.example.com", want: "example.com"},
+		{name: "trailing dot", fqdn: "host.example.com.", want: "example.com"},
+		{name: "bare hostname", fqdn: "host", want: ""},
+		{name: "empty", fqdn: "", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := dnsSuffixFromFQDN(test.fqdn); got != test.want {
+				t.Fatalf("dnsSuffixFromFQDN(%q) = %q, want %q", test.fqdn, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/osinfo.go
+++ b/pkg/utils/osinfo.go
@@ -16,11 +16,34 @@ import (
 	gnet "github.com/shirou/gopsutil/v4/net"
 )
 
+const loopbackInterfaceName = "lo"
+
 // OSInfo holds operating system metadata.
 type OSInfo struct {
 	Name    string
 	Version string
 	Distro  string
+}
+
+// OSNetworkInterface holds OS-reported network adapter details.
+type OSNetworkInterface struct {
+	Name        string `json:"name,omitempty"`
+	IPAddress   string `json:"ipAddress,omitempty"`
+	DHCPEnabled *bool  `json:"dhcpEnabled,omitempty"`
+	LinkStatus  string `json:"linkStatus,omitempty"`
+	MACAddress  string `json:"macAddress,omitempty"`
+}
+
+// OSNetworkAdapters groups OS-reported wired and wireless adapters.
+type OSNetworkAdapters struct {
+	Wired    []OSNetworkInterface `json:"wired,omitempty"`
+	Wireless *OSNetworkInterface  `json:"wireless,omitempty"`
+}
+
+// PlatformAdapters summarizes platform adapter names.
+type PlatformAdapters struct {
+	Wired    string `json:"wired,omitempty"`
+	Wireless string `json:"wireless,omitempty"`
 }
 
 // GetOSInfo returns the OS name, kernel/build version, and distro string.
@@ -96,7 +119,7 @@ func GetOSIPAddress() string {
 
 	for _, iface := range ifaces {
 		name := strings.ToLower(iface.Name)
-		if name == "lo" || strings.Contains(name, "loopback") {
+		if name == loopbackInterfaceName || strings.Contains(name, "loopback") {
 			continue
 		}
 
@@ -131,6 +154,112 @@ func GetOSIPAddress() string {
 	return fallback
 }
 
+// GetOSNetworkAdapters returns non-virtual OS network adapters grouped by type.
+func GetOSNetworkAdapters() OSNetworkAdapters {
+	ifaces, err := gnet.Interfaces()
+	if err != nil {
+		return OSNetworkAdapters{}
+	}
+
+	adapters := OSNetworkAdapters{}
+
+	for _, iface := range ifaces {
+		name := strings.ToLower(iface.Name)
+		if name == loopbackInterfaceName || strings.Contains(name, "loopback") || iface.HardwareAddr == "" || isVirtualAdapter(name) {
+			continue
+		}
+
+		wireless := isWirelessAdapter(name)
+
+		wired := isPhysicalEthernet(name)
+		if !wireless && !wired {
+			continue
+		}
+
+		adapter := OSNetworkInterface{
+			Name:        iface.Name,
+			IPAddress:   firstUsableIPv4(iface.Addrs),
+			DHCPEnabled: getAdapterDHCPEnabled(iface.Name),
+			LinkStatus:  linkStatusFromFlags(iface.Flags),
+			MACAddress:  iface.HardwareAddr,
+		}
+
+		if wireless {
+			if adapters.Wireless == nil {
+				adapters.Wireless = &adapter
+			}
+
+			continue
+		}
+
+		adapters.Wired = append(adapters.Wired, adapter)
+	}
+
+	return adapters
+}
+
+// GetPlatformAdapters returns a best-effort wired/wireless adapter name summary.
+func GetPlatformAdapters() PlatformAdapters {
+	ifaces, err := gnet.Interfaces()
+	if err != nil {
+		return PlatformAdapters{}
+	}
+
+	adapters := PlatformAdapters{}
+
+	for _, iface := range ifaces {
+		name := strings.ToLower(iface.Name)
+		if name == loopbackInterfaceName || strings.Contains(name, "loopback") || iface.HardwareAddr == "" || isVirtualAdapter(name) {
+			continue
+		}
+
+		if isWirelessAdapter(name) {
+			if adapters.Wireless == "" {
+				adapters.Wireless = adapterDisplayName(iface.Name)
+			}
+
+			continue
+		}
+
+		if isPhysicalEthernet(name) && adapters.Wired == "" {
+			adapters.Wired = adapterDisplayName(iface.Name)
+		}
+	}
+
+	return adapters
+}
+
+func firstUsableIPv4(addrs []gnet.InterfaceAddr) string {
+	for _, addr := range addrs {
+		ip := strings.SplitN(addr.Addr, "/", 2)[0]
+		if ip == "" || strings.Contains(ip, ":") || strings.HasPrefix(ip, "169.254.") {
+			continue
+		}
+
+		return ip
+	}
+
+	return ""
+}
+
+func linkStatusFromFlags(flags []string) string {
+	for _, flag := range flags {
+		if strings.EqualFold(flag, "up") {
+			return "up"
+		}
+	}
+
+	return "down"
+}
+
+func adapterDisplayName(interfaceName string) string {
+	if displayName := getAdapterDisplayName(interfaceName); strings.TrimSpace(displayName) != "" {
+		return strings.TrimSpace(displayName)
+	}
+
+	return interfaceName
+}
+
 // isVirtualAdapter returns true for known virtual/software adapter names.
 func isVirtualAdapter(name string) bool {
 	virtualPrefixes := []string{
@@ -161,6 +290,14 @@ func isPhysicalEthernet(name string) bool {
 		strings.HasPrefix(name, "ethernet ")
 }
 
+func isWirelessAdapter(name string) bool {
+	return strings.HasPrefix(name, "wl") ||
+		strings.HasPrefix(name, "wlan") ||
+		strings.Contains(name, "wi-fi") ||
+		strings.Contains(name, "wifi") ||
+		strings.Contains(name, "wireless")
+}
+
 // GetEthernetAdapterCount returns the number of physical ethernet adapters.
 func GetEthernetAdapterCount() int {
 	ifaces, err := gnet.Interfaces()
@@ -172,11 +309,11 @@ func GetEthernetAdapterCount() int {
 
 	for _, iface := range ifaces {
 		name := strings.ToLower(iface.Name)
-		if name == "lo" || strings.Contains(name, "loopback") || iface.HardwareAddr == "" {
+		if name == loopbackInterfaceName || strings.Contains(name, "loopback") || iface.HardwareAddr == "" {
 			continue
 		}
 
-		if strings.HasPrefix(name, "eth") || strings.HasPrefix(name, "en") {
+		if isPhysicalEthernet(name) {
 			count++
 		}
 	}

--- a/pkg/utils/osinfo.go
+++ b/pkg/utils/osinfo.go
@@ -169,7 +169,7 @@ func GetOSNetworkAdapters() OSNetworkAdapters {
 			continue
 		}
 
-		wireless := isWirelessAdapter(name)
+		wireless := isWirelessInterface(iface.Name)
 
 		wired := isPhysicalEthernet(name)
 		if !wireless && !wired {
@@ -213,7 +213,7 @@ func GetPlatformAdapters() PlatformAdapters {
 			continue
 		}
 
-		if isWirelessAdapter(name) {
+		if isWirelessInterface(iface.Name) {
 			adapters.Wireless = append(adapters.Wireless, adapterDisplayName(iface.Name))
 
 			continue
@@ -289,6 +289,8 @@ func isPhysicalEthernet(name string) bool {
 }
 
 func isWirelessAdapter(name string) bool {
+	name = strings.ToLower(name)
+
 	return strings.HasPrefix(name, "wl") ||
 		strings.HasPrefix(name, "wlan") ||
 		strings.Contains(name, "wi-fi") ||
@@ -296,7 +298,7 @@ func isWirelessAdapter(name string) bool {
 		strings.Contains(name, "wireless")
 }
 
-// GetEthernetAdapterCount returns the number of physical ethernet adapters.
+// GetEthernetAdapterCount returns the number of physical wired and wireless adapters.
 func GetEthernetAdapterCount() int {
 	ifaces, err := gnet.Interfaces()
 	if err != nil {
@@ -307,11 +309,11 @@ func GetEthernetAdapterCount() int {
 
 	for _, iface := range ifaces {
 		name := strings.ToLower(iface.Name)
-		if name == loopbackInterfaceName || strings.Contains(name, "loopback") || iface.HardwareAddr == "" {
+		if name == loopbackInterfaceName || strings.Contains(name, "loopback") || iface.HardwareAddr == "" || isVirtualAdapter(name) {
 			continue
 		}
 
-		if isPhysicalEthernet(name) {
+		if isPhysicalEthernet(name) || isWirelessInterface(iface.Name) {
 			count++
 		}
 	}

--- a/pkg/utils/osinfo.go
+++ b/pkg/utils/osinfo.go
@@ -40,10 +40,10 @@ type OSNetworkAdapters struct {
 	Wireless *OSNetworkInterface  `json:"wireless,omitempty"`
 }
 
-// PlatformAdapters summarizes platform adapter names.
+// PlatformAdapters summarizes platform adapter names by connection type.
 type PlatformAdapters struct {
-	Wired    string `json:"wired,omitempty"`
-	Wireless string `json:"wireless,omitempty"`
+	Wired    []string `json:"wired,omitempty"`
+	Wireless []string `json:"wireless,omitempty"`
 }
 
 // GetOSInfo returns the OS name, kernel/build version, and distro string.
@@ -198,7 +198,7 @@ func GetOSNetworkAdapters() OSNetworkAdapters {
 	return adapters
 }
 
-// GetPlatformAdapters returns a best-effort wired/wireless adapter name summary.
+// GetPlatformAdapters returns best-effort wired/wireless adapter display names.
 func GetPlatformAdapters() PlatformAdapters {
 	ifaces, err := gnet.Interfaces()
 	if err != nil {
@@ -214,15 +214,13 @@ func GetPlatformAdapters() PlatformAdapters {
 		}
 
 		if isWirelessAdapter(name) {
-			if adapters.Wireless == "" {
-				adapters.Wireless = adapterDisplayName(iface.Name)
-			}
+			adapters.Wireless = append(adapters.Wireless, adapterDisplayName(iface.Name))
 
 			continue
 		}
 
-		if isPhysicalEthernet(name) && adapters.Wired == "" {
-			adapters.Wired = adapterDisplayName(iface.Name)
+		if isPhysicalEthernet(name) {
+			adapters.Wired = append(adapters.Wired, adapterDisplayName(iface.Name))
 		}
 	}
 

--- a/pkg/utils/osinfo_linux.go
+++ b/pkg/utils/osinfo_linux.go
@@ -7,7 +7,9 @@ package utils
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -73,4 +75,55 @@ func parseMEIModuleVersionFromPath(modulePath string) (string, bool) {
 	}
 
 	return version, true
+}
+
+func getAdapterDHCPEnabled(interfaceName string) *bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "nmcli", "-g", "GENERAL.CONNECTION", "device", "show", interfaceName).Output()
+	if err != nil {
+		return nil
+	}
+
+	connectionName := strings.TrimSpace(string(out))
+	if connectionName == "" || connectionName == "--" {
+		return nil
+	}
+
+	out, err = exec.CommandContext(ctx, "nmcli", "-g", "ipv4.method", "connection", "show", connectionName).Output()
+	if err != nil {
+		return nil
+	}
+
+	method := strings.ToLower(strings.TrimSpace(string(out)))
+	if method == "" {
+		return nil
+	}
+
+	enabled := method == "auto"
+
+	return &enabled
+}
+
+func getAdapterDisplayName(interfaceName string) string {
+	devicePath, err := os.Readlink(filepath.Join("/sys/class/net", interfaceName, "device"))
+	if err != nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "lspci", "-D", "-s", filepath.Base(devicePath)).Output()
+	if err != nil {
+		return ""
+	}
+
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 {
+		return ""
+	}
+
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(out)), fields[0]))
 }

--- a/pkg/utils/osinfo_linux.go
+++ b/pkg/utils/osinfo_linux.go
@@ -77,6 +77,16 @@ func parseMEIModuleVersionFromPath(modulePath string) (string, bool) {
 	return version, true
 }
 
+func isWirelessInterface(name string) bool {
+	if isWirelessAdapter(name) {
+		return true
+	}
+
+	_, err := os.Stat(filepath.Join("/sys/class/net", name, "wireless"))
+
+	return err == nil
+}
+
 func getAdapterDHCPEnabled(interfaceName string) *bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/pkg/utils/osinfo_other.go
+++ b/pkg/utils/osinfo_other.go
@@ -11,3 +11,11 @@ package utils
 func GetMEIDriverVersion() string {
 	return ""
 }
+
+func getAdapterDHCPEnabled(string) *bool {
+	return nil
+}
+
+func getAdapterDisplayName(string) string {
+	return ""
+}

--- a/pkg/utils/osinfo_other.go
+++ b/pkg/utils/osinfo_other.go
@@ -12,6 +12,10 @@ func GetMEIDriverVersion() string {
 	return ""
 }
 
+func isWirelessInterface(name string) bool {
+	return isWirelessAdapter(name)
+}
+
 func getAdapterDHCPEnabled(string) *bool {
 	return nil
 }

--- a/pkg/utils/osinfo_test.go
+++ b/pkg/utils/osinfo_test.go
@@ -1,0 +1,36 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package utils
+
+import "testing"
+
+func TestIsPhysicalEthernet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "eth0", want: true},
+		{name: "enp100s0", want: true},
+		{name: "ethernet", want: true},
+		{name: "ethernet 2", want: true},
+		{name: "wi-fi", want: false},
+		{name: "wlan0", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isPhysicalEthernet(tt.name); got != tt.want {
+				t.Fatalf("isPhysicalEthernet(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/osinfo_test.go
+++ b/pkg/utils/osinfo_test.go
@@ -34,3 +34,29 @@ func TestIsPhysicalEthernet(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWirelessAdapter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "wlo1", want: true},
+		{name: "Wi-Fi", want: true},
+		{name: "Network controller: Intel Corporation Meteor Lake PCH CNVi WiFi (rev 20)", want: true},
+		{name: "Ethernet", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isWirelessAdapter(tt.name); got != tt.want {
+				t.Fatalf("isWirelessAdapter(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/osinfo_windows.go
+++ b/pkg/utils/osinfo_windows.go
@@ -52,3 +52,54 @@ func GetMEIDriverVersion() string {
 
 	return strings.TrimSpace(string(out))
 }
+
+func getAdapterDHCPEnabled(interfaceName string) *bool {
+	ctx, cancel := context.WithTimeout(context.Background(), osInfoTimeout)
+	defer cancel()
+
+	psBinary := findPowerShellBinary()
+	if psBinary == "" {
+		return nil
+	}
+
+	name := escapePowerShellSingleQuotedString(interfaceName)
+	script := "$idx = (Get-CimInstance Win32_NetworkAdapter | Where-Object { $_.NetConnectionID -eq '" + name + "' -or $_.Name -eq '" + name + "' } | Select-Object -First 1 -ExpandProperty InterfaceIndex); if ($idx -ne $null) { (Get-CimInstance Win32_NetworkAdapterConfiguration -Filter \"InterfaceIndex=$idx\").DHCPEnabled }"
+	out, err := runCommandOutput(ctx, psBinary, "-NoProfile", "-Command", script)
+	if err != nil {
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(string(out))) {
+	case "true":
+		enabled := true
+		return &enabled
+	case "false":
+		enabled := false
+		return &enabled
+	default:
+		return nil
+	}
+}
+
+func getAdapterDisplayName(interfaceName string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), osInfoTimeout)
+	defer cancel()
+
+	psBinary := findPowerShellBinary()
+	if psBinary == "" {
+		return ""
+	}
+
+	name := escapePowerShellSingleQuotedString(interfaceName)
+	script := "Get-CimInstance Win32_NetworkAdapter | Where-Object { $_.NetConnectionID -eq '" + name + "' -or $_.Name -eq '" + name + "' } | Select-Object -First 1 -ExpandProperty Name"
+	out, err := runCommandOutput(ctx, psBinary, "-NoProfile", "-Command", script)
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+func escapePowerShellSingleQuotedString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}

--- a/pkg/utils/osinfo_windows.go
+++ b/pkg/utils/osinfo_windows.go
@@ -53,6 +53,10 @@ func GetMEIDriverVersion() string {
 	return strings.TrimSpace(string(out))
 }
 
+func isWirelessInterface(name string) bool {
+	return isWirelessAdapter(name)
+}
+
 func getAdapterDHCPEnabled(interfaceName string) *bool {
 	ctx, cancel := context.WithTimeout(context.Background(), osInfoTimeout)
 	defer cancel()


### PR DESCRIPTION
* send ME and OS network interface details during device sync
* collect OS DNS suffix, DHCP state, and adapter names
* reuse post-activation WSMAN for TLS and IEEE 802.1x discovery

Addresses #1513

## Dependencies

- Console export endpoint: device-management-toolkit/console#1209.
- Companion Console mapping PR: device-management-toolkit/console#1233.

## Implementation Details:

| Field | Linux | Windows |
|---|---|---|
| `dnsSuffixOS` | `AMTCommand.GetOSDNSSuffix()` tries OS FQDN via hostname/DNS lookup, then falls back to `nmcli -g IP4.DOMAIN,IP4.SEARCHES device show`. Comma-separated NetworkManager search domains are split and the first usable domain is used. | `GetAdaptersAddresses()` matches the active AMT wired MAC to the OS adapter and reads its DNS suffix. |
| `meNetwork.wired.ipAddress` | HECI `GetLANInterfaceSettings(false).IPAddress` | HECI `GetLANInterfaceSettings(false).IPAddress` |
| `meNetwork.wired.dhcpEnabled` | HECI `GetLANInterfaceSettings(false).DHCPEnabled` | HECI `GetLANInterfaceSettings(false).DHCPEnabled` |
| `meNetwork.wired.dhcpMode` | HECI `GetLANInterfaceSettings(false).DHCPMode` | HECI `GetLANInterfaceSettings(false).DHCPMode` |
| `meNetwork.wired.linkStatus` | HECI `GetLANInterfaceSettings(false).LinkStatus` | HECI `GetLANInterfaceSettings(false).LinkStatus` |
| `meNetwork.wired.macAddress` | HECI `GetLANInterfaceSettings(false).MACAddress` | HECI `GetLANInterfaceSettings(false).MACAddress` |
| `meNetwork.wireless.ipAddress` | HECI `GetLANInterfaceSettings(true).IPAddress` | HECI `GetLANInterfaceSettings(true).IPAddress` |
| `meNetwork.wireless.dhcpEnabled` | HECI `GetLANInterfaceSettings(true).DHCPEnabled` | HECI `GetLANInterfaceSettings(true).DHCPEnabled` |
| `meNetwork.wireless.dhcpMode` | HECI `GetLANInterfaceSettings(true).DHCPMode` | HECI `GetLANInterfaceSettings(true).DHCPMode` |
| `meNetwork.wireless.linkStatus` | HECI `GetLANInterfaceSettings(true).LinkStatus` | HECI `GetLANInterfaceSettings(true).LinkStatus` |
| `meNetwork.wireless.macAddress` | HECI `GetLANInterfaceSettings(true).MACAddress` | HECI `GetLANInterfaceSettings(true).MACAddress` |
| `osNetwork.wired[].name` | `gopsutil/v4/net.Interfaces()` filtered by physical wired names such as `eth*` and `en*` | `gopsutil/v4/net.Interfaces()` filtered by Windows wired names such as `Ethernet` and `Ethernet 2` |
| `osNetwork.wired[].ipAddress` | First usable IPv4 on each wired interface; skips IPv6 and `169.254.*` link-local addresses | First usable IPv4 on each wired interface; skips IPv6 and `169.254.*` link-local addresses |
| `osNetwork.wired[].dhcpEnabled` | Best-effort `nmcli` lookup of active connection `ipv4.method == auto` | PowerShell/CIM: matches `Win32_NetworkAdapter` by interface name, then reads `Win32_NetworkAdapterConfiguration.DHCPEnabled` by `InterfaceIndex` |
| `osNetwork.wired[].linkStatus` | `gopsutil` interface flags; `up` when the interface has the `up` flag, otherwise `down` | `gopsutil` interface flags; `up` when the interface has the `up` flag, otherwise `down` |
| `osNetwork.wired[].macAddress` | `gopsutil` interface hardware address | `gopsutil` interface hardware address |
| `osNetwork.wireless.*` | First non-virtual wireless interface detected by case-insensitive name matching or the Linux sysfs `/sys/class/net/<interface>/wireless` marker | First non-virtual wireless interface detected by case-insensitive `wifi`, `wi-fi`, or `wireless` name matching |
| `platformAdapters.wired[]` | Display names for all detected physical wired adapters; prefers `lspci` match when available, otherwise interface name | Display names for all detected wired adapters from `Win32_NetworkAdapter.Name`, matched by `NetConnectionID` or `Name` |
| `platformAdapters.wireless[]` | Display names for all detected wireless adapters; prefers `lspci` match when available, otherwise interface name | Display names for all detected wireless adapters from `Win32_NetworkAdapter.Name`, matched by `NetConnectionID` or `Name` |
| `ethernetAdapterCount` | Counts all detected physical wired and wireless adapters; excludes loopback and known virtual/software interfaces | Counts all detected physical wired and wireless adapters; excludes loopback and known virtual/software interfaces |

## Notes:

- `platformAdapters.wired` and `platformAdapters.wireless` are arrays and contain all detected adapter display names.
- `ethernetAdapterCount` retains its existing field name for API compatibility, but now represents the total number of detected physical wired and wireless adapters.
- Virtual/software adapters such as Hyper-V/WSL, VMware, VirtualBox, Docker, bridge, veth, and libvirt interfaces are filtered where identifiable.
- OS-level DHCP detection is best effort and may be omitted when NetworkManager or Windows CIM information is unavailable.
- The sync payload includes ME, OS, and platform adapter information at debug level to help diagnose data sent to Console.

## Output

Query from host:

```bash
TOKEN=$(curl -sk https://localhost:8181/api/v1/authorize -H "Content-Type: application/json" -d '{"username":"<username>","password":"<password>"}' | jq -r '.token') && curl -sk https://localhost:8181/api/v1/devices -H "Authorization: Bearer $TOKEN" | jq '[.[] | {hostname, guid, deviceInfo}]'
[]
```

Sync before activation (Device in pre-provisioning state):

```bash
sudo ./rpc amtinfo --sync --url https://<host_ip_addr>:8181/api/v1/devices \
  --auth-endpoint https://<host_ip_addr>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug -v
```
  
Query from host:

```bash
curl -sk https://localhost:8181/api/v1/devices \
  -H "Authorization: Bearer $TOKEN" | jq '[.[] | {hostname, guid, deviceInfo}]'
```

```json
[
  {
    "hostname": "<edge-node-ip-addr>",
    "guid": "<edge-node-guid>",
    "deviceInfo": {
      "fwVersion": "16.1.35",
      "fwBuild": "2557",
      "fwSku": "16392",
      "discovered": true,
      "firstDiscovered": "2026-09-02T04:55:13.44962452Z",
      "currentMode": "not activated",
      "features": "AMT Pro Corporate",
      "ipAddress": "<edge-node-ip-addr>",
      "lastSynced": "2026-09-02T04:55:13.44962452Z",
      "lmsInstalled": true,
      "lmsVersion": "2406.0.0.0",
      "upid": {
        "csmeId": "<edge-node-csmeId>",
        "oemId": "<edge-node-oemId>",
        "oemPlatformIdType": "Not Set (0)"
      },
      "amtEnabledInBIOS": true,
      "meInterfaceVersion": "6.8.0-94-generic",
      "dhcpEnabled": true,
      "certHashes": [
        "<cert-hash-1>",
        "<cert-hash-2>"
      ],
      "osName": "linux",
      "osVersion": "6.8.0-94-generic",
      "osDistro": "Ubuntu 22.04.5 LTS",
      "dnsSuffixOS": "test.example.com",
      "cpuModel": "12th Gen Intel(R) Core(TM) i5-1250P",
      "osIpAddress": "<edge-node-ip-addr>",
      "ethernetAdapterCount": 2,
      "monitorConnected": true,
      "meNetwork": {
        "wired": {
          "ipAddress": "0.0.0.0",
          "dhcpEnabled": true,
          "dhcpMode": "passive",
          "linkStatus": "up",
          "macAddress": "xx:xx:xx:xx:xx:xx"
        },
        "wireless": {
          "ipAddress": "0.0.0.0",
          "dhcpEnabled": true,
          "dhcpMode": "active",
          "linkStatus": "down",
          "macAddress": "xx:xx:xx:xx:xx:xx"
        }
      },
      "osNetwork": {
        "wired": [
          {
            "name": "enp100s0",
            "ipAddress": "<edge-node-ip-addr>",
            "dhcpEnabled": true,
            "linkStatus": "up",
            "macAddress": "xx:xx:xx:xx:xx:xx"
          }
        ],
        "wireless": {
          "name": "wlo1",
          "linkStatus": "up",
          "macAddress": "xx:xx:xx:xx:xx:xx"
        }
      },
      "platformAdapters": {
        "wired": [
          "Ethernet controller: Intel Corporation Ethernet Controller I225-LM (rev 03)"
        ],
        "wireless": [
          "Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)"
        ]
      }
    }
  }
]
```

Run the export API command:

```bash
curl -sk https://localhost:8181/api/v1/devices/export \
  -H "Authorization: Bearer $TOKEN" | jq
```

```json
{
  "metadata": {
    "exportedAt": "2026-09-02T04:54:34.538612812Z",
    "swVersion": "console DEVELOPMENT"
  },
  "summary": {
    "totalCount": 1
  },
  "data": [
    {
      "guid": "<edge-node-guid>",
      "hostname": "<edge-node-ip-addr>",
      "friendlyName": "",
      "tags": [],
      "tenantId": "",
      "firstDiscovered": "2026-09-02T04:55:13.44962452Z",
      "lastSynced": "2026-09-02T04:55:13.44962452Z",
      "lastUpdated": null,
      "deviceInfo": {
        "me": {
          "dnsSuffix": "",
          "currentMode": "not activated",
          "mebxEnabledInBIOS": true,
          "fwVersion": "16.1.35",
          "fwBuild": "2557",
          "fwSku": "16392",
          "features": "AMT Pro Corporate",
          "tlsMode": "",
          "dhcpEnabled": true,
          "certHashes": [
            "<cert-hash-1>",
            "<cert-hash-2>"
          ],
          "upid": {
            "csmeId": "<edge-node-csmeId>",
            "oemId": "<edge-node-oemId>",
            "oemPlatformIdType": "Not Set (0)"
          },
          "network": {
            "wired": {
              "ipAddress": "0.0.0.0",
              "dhcpEnabled": true,
              "dhcpMode": "passive",
              "linkStatus": "up",
              "macAddress": "xx:xx:xx:xx:xx:xx"
            },
            "wireless": {
              "ipAddress": "0.0.0.0",
              "dhcpEnabled": true,
              "dhcpMode": "active",
              "linkStatus": "down",
              "macAddress": "xx:xx:xx:xx:xx:xx"
            }
          }
        },
        "os": {
          "dnsSuffix": "test.example.com",
          "name": "linux",
          "version": "6.8.0-94-generic",
          "distro": "Ubuntu 22.04.5 LTS",
          "lmsInstalled": true,
          "lmsVersion": "2406.0.0.0",
          "meInterfaceVersion": "6.8.0-94-generic",
          "monitorConnected": true,
          "ieee8021xEnabled": null,
          "network": {
            "wired": [
              {
                "name": "enp100s0",
                "ipAddress": "<edge-node-ip-addr>",
                "dhcpEnabled": true,
                "linkStatus": "up",
                "macAddress": "xx:xx:xx:xx:xx:xx"
              }
            ],
            "wireless": {
              "name": "wlo1",
              "ipAddress": "",
              "dhcpEnabled": null,
              "linkStatus": "up",
              "macAddress": "xx:xx:xx:xx:xx:xx"
            }
          }
        },
        "platform": {
          "cpu": "12th Gen Intel(R) Core(TM) i5-1250P",
          "ethernetAdapterCount": 2,
          "adapters": {
            "wired": [
              "Ethernet controller: Intel Corporation Ethernet Controller I225-LM (rev 03)"
            ],
            "wireless": [
              "Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)"
            ]
          }
        },
        "bmc": null
      }
    }
  ]
}
```

Activate the edge node:

```bash
sudo ./rpc activate --local \
  --profile /path-to-profile/profile.yaml \
  --key "<profile-key>" \
  --skip-amt-cert-check --skip-cert-check \
  --auth-endpoint "https://<host_ip_addr>:8181/api/v1/authorize" \
  --auth-username <username> --auth-password "<password>" \
  --devices-endpoint "https://<host_ip_addr>:8181/api/v1/devices" \
  --log-level=debug -v
```

Query from host:

```bash
curl -sk https://localhost:8181/api/v1/devices \
  -H "Authorization: Bearer $TOKEN" | jq '[.[] | {hostname, guid, deviceInfo}]'
```

```json
[
  {
    "hostname": "<edge-node-ip-addr>",
    "guid": "<edge-node-guid>",
    "deviceInfo": {
      "fwVersion": "16.1.35",
      "fwBuild": "2557",
      "fwSku": "16392",
      "discovered": true,
      "firstDiscovered": "2026-09-02T04:55:13.44962452Z",
      "currentMode": "admin control mode",
      "features": "AMT Pro Corporate",
      "ipAddress": "<edge-node-ip-addr>",
      "lastSynced": "2026-09-02T04:56:00.349157022Z",
      "lmsInstalled": true,
      "lmsVersion": "2406.0.0.0",
      "tlsMode": "Server",
      "upid": {
        "csmeId": "<edge-node-csmeId>",
        "oemId": "<edge-node-oemId>",
        "oemPlatformIdType": "Not Set (0)"
      },
      "amtEnabledInBIOS": true,
      "meInterfaceVersion": "6.8.0-94-generic",
      "dhcpEnabled": true,
      "certHashes": [
        "<cert-hash-1>",
        "<cert-hash-2>"
      ],
      "osName": "linux",
      "osVersion": "6.8.0-94-generic",
      "osDistro": "Ubuntu 22.04.5 LTS",
      "dnsSuffixOS": "test.example.com",
      "cpuModel": "12th Gen Intel(R) Core(TM) i5-1250P",
      "osIpAddress": "<edge-node-ip-addr>",
      "ethernetAdapterCount": 2,
      "monitorConnected": true,
      "ieee8021xEnabled": false,
      "meNetwork": {
        "wired": {
          "ipAddress": "<edge-node-ip-addr>",
          "dhcpEnabled": true,
          "dhcpMode": "passive",
          "linkStatus": "up",
          "macAddress": "xx:xx:xx:xx:xx:xx"
        },
        "wireless": {
          "ipAddress": "0.0.0.0",
          "dhcpEnabled": true,
          "dhcpMode": "active",
          "linkStatus": "down",
          "macAddress": "xx:xx:xx:xx:xx:xx"
        }
      },
      "osNetwork": {
        "wired": [
          {
            "name": "enp100s0",
            "ipAddress": "<edge-node-ip-addr>",
            "dhcpEnabled": true,
            "linkStatus": "up",
            "macAddress": "xx:xx:xx:xx:xx:xx"
          }
        ],
        "wireless": {
          "name": "wlo1",
          "linkStatus": "up",
          "macAddress": "xx:xx:xx:xx:xx:xx"
        }
      },
      "platformAdapters": {
        "wired": [
          "Ethernet controller: Intel Corporation Ethernet Controller I225-LM (rev 03)"
        ],
        "wireless": [
          "Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)"
        ]
      }
    }
  }
]
```

Run the export API command:

```bash
curl -sk https://localhost:8181/api/v1/devices/export \
  -H "Authorization: Bearer $TOKEN" | jq
```

```json
{
  "metadata": {
    "exportedAt": "2026-09-02T04:55:04.822955349Z",
    "swVersion": "console DEVELOPMENT"
  },
  "summary": {
    "totalCount": 1
  },
  "data": [
    {
      "guid": "<edge-node-guid>",
      "hostname": "<edge-node-ip-addr>",
      "friendlyName": "BA38RNL00649",
      "tags": [
        "AMT16",
        " Aug31",
        "acm",
        "nonTLS"
      ],
      "tenantId": "",
      "firstDiscovered": "2026-09-02T04:55:13.44962452Z",
      "lastSynced": "2026-09-02T04:56:00.349157022Z",
      "lastUpdated": null,
      "deviceInfo": {
        "me": {
          "dnsSuffix": "",
          "currentMode": "admin control mode",
          "mebxEnabledInBIOS": true,
          "fwVersion": "16.1.35",
          "fwBuild": "2557",
          "fwSku": "16392",
          "features": "AMT Pro Corporate",
          "tlsMode": "Server",
          "dhcpEnabled": true,
          "certHashes": [
            "<cert-hash-1>",
            "<cert-hash-2>"
          ],
          "upid": {
            "csmeId": "<edge-node-csmeId>",
            "oemId": "<edge-node-oemId>",
            "oemPlatformIdType": "Not Set (0)"
          },
          "network": {
            "wired": {
              "ipAddress": "<edge-node-ip-addr>",
              "dhcpEnabled": true,
              "dhcpMode": "passive",
              "linkStatus": "up",
              "macAddress": "xx:xx:xx:xx:xx:xx"
            },
            "wireless": {
              "ipAddress": "0.0.0.0",
              "dhcpEnabled": true,
              "dhcpMode": "active",
              "linkStatus": "down",
              "macAddress": "xx:xx:xx:xx:xx:xx"
            }
          }
        },
        "os": {
          "dnsSuffix": "test.example.com",
          "name": "linux",
          "version": "6.8.0-94-generic",
          "distro": "Ubuntu 22.04.5 LTS",
          "lmsInstalled": true,
          "lmsVersion": "2406.0.0.0",
          "meInterfaceVersion": "6.8.0-94-generic",
          "monitorConnected": true,
          "ieee8021xEnabled": false,
          "network": {
            "wired": [
              {
                "name": "enp100s0",
                "ipAddress": "<edge-node-ip-addr>",
                "dhcpEnabled": true,
                "linkStatus": "up",
                "macAddress": "xx:xx:xx:xx:xx:xx"
              }
            ],
            "wireless": {
              "name": "wlo1",
              "ipAddress": "",
              "dhcpEnabled": null,
              "linkStatus": "up",
              "macAddress": "xx:xx:xx:xx:xx:xx"
            }
          }
        },
        "platform": {
          "cpu": "12th Gen Intel(R) Core(TM) i5-1250P",
          "ethernetAdapterCount": 2,
          "adapters": {
            "wired": [
              "Ethernet controller: Intel Corporation Ethernet Controller I225-LM (rev 03)"
            ],
            "wireless": [
              "Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)"
            ]
          }
        },
        "bmc": null
      }
    }
  ]
}
```

Run the deactivate command:
For local deactivation with console auth flags: (If you want auto sync after deactivation:)

```bash
sudo ./rpc deactivate --local --skip-amt-cert-check --skip-cert-check \
  --auth-endpoint "https://<host_ip_addr>:8181/api/v1/authorize" \
  --auth-username "<username>" \
  --auth-password "<password>" -v --log-level=debug
```

Query from host:

```bash
curl -sk https://localhost:8181/api/v1/devices -H "Authorization: Bearer $TOKEN" | jq '[.[] | {hostname, guid, deviceInfo}]'
[]
```